### PR TITLE
Fix CI pipeline failures: update GitHub Actions versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,13 @@ jobs:
       matrix:
         node-version: [18.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v4.1.0
         with:
-          version: 7.*
+          version: 8
       - run: pnpm install
       - run: pnpm test


### PR DESCRIPTION
## Summary
- Update pnpm/action-setup from v2.2.2 to v4.1.0 to resolve pnpm installation failures
- Update actions/checkout from v2 to v4 for better compatibility
- Update actions/setup-node from v1 to v4 for improved performance
- Update pnpm version from 7.* to 8 to match latest stable release

## Test plan
- [x] Run local test suite to verify no regressions
- [x] Verify all GitHub Actions use current supported versions
- [ ] Monitor CI pipeline execution after merge