### PR TITLE
feat: implement CouchDB backup/restore phase 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "zod": "^3.25.67"
   },
   "devDependencies": {
+    "@cloudant/couchbackup": "^2.11.7",
     "@eslint/js": "^9.29.0",
     "@swc/core": "^1.3.3",
     "@tailwindcss/typography": "^0.5.8",
@@ -83,7 +84,10 @@
     "knip": "knip",
     "test:mcp": "node scripts/test-mcp.js",
     "test:mcp:integration": "pnpm --filter @eddo/server test:integration",
-    "test:mcp:integration:watch": "pnpm --filter @eddo/server test:integration:watch"
+    "test:mcp:integration:watch": "pnpm --filter @eddo/server test:integration:watch",
+    "backup": "node scripts/backup.js",
+    "restore": "node scripts/restore.js",
+    "backup:verify": "node scripts/verify-backup.js"
   },
   "browserslist": [
     ">0.2%",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
         specifier: ^3.25.67
         version: 3.25.67
     devDependencies:
+      '@cloudant/couchbackup':
+        specifier: ^2.11.7
+        version: 2.11.7(@types/tough-cookie@4.0.5)(axios@1.10.0)(extend@3.0.2)(ibm-cloud-sdk-core@5.4.0)(tough-cookie@5.1.2)
       '@eslint/js':
         specifier: ^9.29.0
         version: 9.29.0
@@ -248,6 +251,9 @@ importers:
         specifier: ^3.25.67
         version: 3.25.67
     devDependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.13.1
+        version: 1.13.1
       '@types/node':
         specifier: ^24.0.3
         version: 24.0.3
@@ -257,6 +263,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.3)(jiti@2.4.2)(jsdom@26.1.0)(tsx@4.20.3)(yaml@2.8.0)
 
   packages/shared:
     dependencies:
@@ -436,6 +445,14 @@ packages:
   '@babel/types@7.27.6':
     resolution: {integrity: sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==}
     engines: {node: '>=6.9.0'}
+
+  '@cloudant/couchbackup@2.11.7':
+    resolution: {integrity: sha512-jt5KkGXSMwg98gJX/NH1iU1HRMgEL1uc78mhP0RApKPwr7BMONyGXBKzGdTfYtx0WDIbXjICbTAfUUNtlt7/lw==}
+    engines: {node: ^20 || ^22}
+    hasBin: true
+    peerDependencies:
+      axios: ^1.8.2
+      ibm-cloud-sdk-core: ^5.3.2
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -859,6 +876,14 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@ibm-cloud/cloudant@0.12.4':
+    resolution: {integrity: sha512-GymO9+nwoQS+0pcKPUiNqN97w1HGkg9I4p+2imuckPE5pxUGxwLD0iUAja16b6S1WHfh20A6WnOGwaDCVoDKQw==}
+    engines: {node: ^20 || ^22}
+    peerDependencies:
+      '@types/tough-cookie': ^4.0.0
+      extend: ^3.0.2
+      tough-cookie: ^4.0.0
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -1267,6 +1292,9 @@ packages:
   '@types/node@18.19.112':
     resolution: {integrity: sha512-i+Vukt9POdS/MBI7YrrkkI5fMfwFtOjphSmt4WXYLfwqsfr6z/HdCx7LqT9M7JktGob8WNgj8nFB4TbGNE4Cog==}
 
+  '@types/node@20.17.57':
+    resolution: {integrity: sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==}
+
   '@types/node@20.19.1':
     resolution: {integrity: sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==}
 
@@ -1310,6 +1338,9 @@ packages:
 
   '@types/react@18.3.23':
     resolution: {integrity: sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
@@ -1722,6 +1753,9 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
@@ -1755,6 +1789,10 @@ packages:
   camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
 
   caniuse-lite@1.0.30001723:
     resolution: {integrity: sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==}
@@ -1822,6 +1860,10 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  commander@14.0.0:
+    resolution: {integrity: sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==}
+    engines: {node: '>=20'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -2003,6 +2045,9 @@ packages:
 
   easy-bem@1.1.1:
     resolution: {integrity: sha512-GJRqdiy2h+EXy6a8E6R+ubmqUM08BK0FWNq41k24fup6045biQ8NXxoXimiwegMQvFFV3t1emADdGNL1TlS61A==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -2265,6 +2310,9 @@ packages:
     resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
     engines: {node: '>= 18'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -2312,6 +2360,10 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-type@16.5.4:
+    resolution: {integrity: sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==}
+    engines: {node: '>=10'}
 
   file-type@21.0.0:
     resolution: {integrity: sha512-ek5xNX2YBYlXhiUXui3D/BXa3LdqPmoLJ7rqEx2bKJ7EAUEfmXgW0Das7Dc6Nr9MvqaOnIqiPV0mZk/r/UpNAg==}
@@ -2368,6 +2420,10 @@ packages:
 
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+
+  form-data@4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
 
   form-data@4.0.3:
     resolution: {integrity: sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==}
@@ -2551,6 +2607,10 @@ packages:
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  ibm-cloud-sdk-core@5.4.0:
+    resolution: {integrity: sha512-c4cwOuUDbMiFROYM/Ti1aC+Umi1v3TdvC2DO5zR7w44FYY/3xrs79+3DVPXt/nRhJeaMHN2L9XwlXsPSoVDHJA==}
+    engines: {node: '>=18'}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -2749,6 +2809,9 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isstream@0.1.2:
+    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -2812,9 +2875,19 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonwebtoken@9.0.2:
+    resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
+    engines: {node: '>=12', npm: '>=6'}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  jwa@1.4.2:
+    resolution: {integrity: sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==}
+
+  jws@3.2.2:
+    resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2922,11 +2995,29 @@ packages:
   lodash.castarray@4.4.0:
     resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
 
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
 
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -3271,6 +3362,10 @@ packages:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
     engines: {node: '>= 14.16'}
 
+  peek-readable@4.1.0:
+    resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
+    engines: {node: '>=8'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -3475,6 +3570,10 @@ packages:
     resolution: {integrity: sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==}
     engines: {node: '>=18'}
 
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -3566,6 +3665,14 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  readable-web-to-node-stream@3.0.4:
+    resolution: {integrity: sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==}
+    engines: {node: '>=8'}
+
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -3596,6 +3703,12 @@ packages:
   resolve@2.0.0-next.5:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
+
+  retry-axios@2.6.0:
+    resolution: {integrity: sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ==}
+    engines: {node: '>=10.7.0'}
+    peerDependencies:
+      axios: '*'
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -3863,6 +3976,10 @@ packages:
     resolution: {integrity: sha512-3JWEZM6mfix/GCJBBUrkA8p2Id2pBkyTkVCJKto55w080QBKZ+8R171fGrbiSp+yMO/u6F8/yUh7K4V9K+YCnw==}
     engines: {node: '>=18'}
 
+  strtok3@6.3.0:
+    resolution: {integrity: sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==}
+    engines: {node: '>=10'}
+
   sublevel-pouchdb@9.0.0:
     resolution: {integrity: sha512-pX4r8+F7wuts0C81kUJ341h4bl2aRe7qV572FE8X1FMz9VkKlmi2nPD1vfeiOJXz5Y09I4MHjGULAbqvTfQZEQ==}
 
@@ -3954,6 +4071,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  token-types@4.2.1:
+    resolution: {integrity: sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==}
+    engines: {node: '>=10'}
 
   token-types@6.0.0:
     resolution: {integrity: sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==}
@@ -4065,6 +4186,9 @@ packages:
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -4600,6 +4724,19 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
+  '@cloudant/couchbackup@2.11.7(@types/tough-cookie@4.0.5)(axios@1.10.0)(extend@3.0.2)(ibm-cloud-sdk-core@5.4.0)(tough-cookie@5.1.2)':
+    dependencies:
+      '@ibm-cloud/cloudant': 0.12.4(@types/tough-cookie@4.0.5)(extend@3.0.2)(tough-cookie@5.1.2)
+      axios: 1.10.0(debug@4.4.1)
+      commander: 14.0.0
+      debug: 4.4.1
+      ibm-cloud-sdk-core: 5.4.0
+    transitivePeerDependencies:
+      - '@types/tough-cookie'
+      - extend
+      - supports-color
+      - tough-cookie
+
   '@colors/colors@1.6.0': {}
 
   '@cspotcode/source-map-support@0.8.1':
@@ -4879,6 +5016,16 @@ snapshots:
   '@humanwhocodes/retry@0.3.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@ibm-cloud/cloudant@0.12.4(@types/tough-cookie@4.0.5)(extend@3.0.2)(tough-cookie@5.1.2)':
+    dependencies:
+      '@types/node': 20.17.57
+      '@types/tough-cookie': 4.0.5
+      extend: 3.0.2
+      ibm-cloud-sdk-core: 5.4.0
+      tough-cookie: 5.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -5223,6 +5370,10 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
+  '@types/node@20.17.57':
+    dependencies:
+      undici-types: 6.19.8
+
   '@types/node@20.19.1':
     dependencies:
       undici-types: 6.21.0
@@ -5284,6 +5435,8 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.1.3
+
+  '@types/tough-cookie@4.0.5': {}
 
   '@types/triple-beam@1.3.5': {}
 
@@ -5739,9 +5892,9 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.10.0:
+  axios@1.10.0(debug@4.4.1):
     dependencies:
-      follow-redirects: 1.15.9
+      follow-redirects: 1.15.9(debug@4.4.1)
       form-data: 4.0.3
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -5787,6 +5940,8 @@ snapshots:
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.0)
 
+  buffer-equal-constant-time@1.0.1: {}
+
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
@@ -5821,6 +5976,8 @@ snapshots:
   callsites@3.1.0: {}
 
   camelcase-css@2.0.1: {}
+
+  camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001723: {}
 
@@ -5911,6 +6068,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  commander@14.0.0: {}
 
   commander@4.1.1: {}
 
@@ -6068,6 +6227,10 @@ snapshots:
   eastasianwidth@0.2.0: {}
 
   easy-bem@1.1.1: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -6521,6 +6684,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extend@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -6586,6 +6751,12 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  file-type@16.5.4:
+    dependencies:
+      readable-web-to-node-stream: 3.0.4
+      strtok3: 6.3.0
+      token-types: 4.2.1
+
   file-type@21.0.0:
     dependencies:
       '@tokenizer/inflate': 0.2.7
@@ -6640,7 +6811,9 @@ snapshots:
 
   fn.name@1.1.0: {}
 
-  follow-redirects@1.15.9: {}
+  follow-redirects@1.15.9(debug@4.4.1):
+    optionalDependencies:
+      debug: 4.4.1
 
   for-each@0.3.5:
     dependencies:
@@ -6652,6 +6825,12 @@ snapshots:
       signal-exit: 4.1.0
 
   form-data-encoder@1.7.2: {}
+
+  form-data@4.0.0:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
 
   form-data@4.0.3:
     dependencies:
@@ -6841,6 +7020,26 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  ibm-cloud-sdk-core@5.4.0:
+    dependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 18.19.112
+      '@types/tough-cookie': 4.0.5
+      axios: 1.10.0(debug@4.4.1)
+      camelcase: 6.3.0
+      debug: 4.4.1
+      dotenv: 16.5.0
+      extend: 3.0.2
+      file-type: 16.5.4
+      form-data: 4.0.0
+      isstream: 0.1.2
+      jsonwebtoken: 9.0.2
+      mime-types: 2.1.35
+      retry-axios: 2.6.0(axios@1.10.0)
+      tough-cookie: 4.1.4
+    transitivePeerDependencies:
+      - supports-color
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -7015,6 +7214,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isstream@0.1.2: {}
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -7087,12 +7288,36 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonwebtoken@9.0.2:
+    dependencies:
+      jws: 3.2.2
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.2
+
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.9
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  jwa@1.4.2:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@3.2.2:
+    dependencies:
+      jwa: 1.4.2
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -7215,9 +7440,21 @@ snapshots:
 
   lodash.castarray@4.4.0: {}
 
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
   lodash.isplainobject@4.0.6: {}
 
+  lodash.isstring@4.0.1: {}
+
   lodash.merge@4.6.2: {}
+
+  lodash.once@4.1.1: {}
 
   lodash@4.17.21: {}
 
@@ -7333,7 +7570,7 @@ snapshots:
 
   nano@10.1.4:
     dependencies:
-      axios: 1.10.0
+      axios: 1.10.0(debug@4.4.1)
       node-abort-controller: 3.1.1
       qs: 6.14.0
     transitivePeerDependencies:
@@ -7554,6 +7791,8 @@ snapshots:
 
   pathval@2.0.0: {}
 
+  peek-readable@4.1.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -7755,6 +7994,8 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
+  process@0.11.10: {}
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -7850,6 +8091,18 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
+  readable-web-to-node-stream@3.0.4:
+    dependencies:
+      readable-stream: 4.7.0
+
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
@@ -7891,6 +8144,10 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  retry-axios@2.6.0(axios@1.10.0):
+    dependencies:
+      axios: 1.10.0(debug@4.4.1)
 
   reusify@1.1.0: {}
 
@@ -8222,6 +8479,11 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
+  strtok3@6.3.0:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+      peek-readable: 4.1.0
+
   sublevel-pouchdb@9.0.0:
     dependencies:
       level-codec: 9.0.2
@@ -8326,6 +8588,11 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
+
+  token-types@4.2.1:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
 
   token-types@6.0.0:
     dependencies:
@@ -8462,6 +8729,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@5.26.5: {}
+
+  undici-types@6.19.8: {}
 
   undici-types@6.21.0: {}
 

--- a/scripts/backup.js
+++ b/scripts/backup.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/* eslint-env node */
+
+/**
+ * Basic backup script using @cloudant/couchbackup
+ * Backs up CouchDB database to a JSON file
+ */
+
+import fs from 'fs';
+import path from 'path';
+import couchbackup from '@cloudant/couchbackup';
+
+// Configuration
+const COUCH_URL = process.env.COUCH_URL || 'http://localhost:5984';
+const DATABASE = process.env.DATABASE || 'todos';
+const BACKUP_DIR = process.env.BACKUP_DIR || './backups';
+
+async function backup() {
+  try {
+    // Ensure backup directory exists
+    if (!fs.existsSync(BACKUP_DIR)) {
+      fs.mkdirSync(BACKUP_DIR, { recursive: true });
+    }
+
+    // Generate backup filename with timestamp
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const backupFile = path.join(BACKUP_DIR, `${DATABASE}-${timestamp}.json`);
+
+    console.log(`Starting backup of ${DATABASE} database...`);
+    console.log(`Source: ${COUCH_URL}/${DATABASE}`);
+    console.log(`Destination: ${backupFile}`);
+
+    const writeStream = fs.createWriteStream(backupFile);
+    
+    await new Promise((resolve, reject) => {
+      couchbackup.backup(
+        `${COUCH_URL}/${DATABASE}`,
+        writeStream,
+        {
+          parallelism: 5,
+          requestTimeout: 60000,
+          logfile: `${backupFile}.log`
+        },
+        (err, data) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(data);
+          }
+        }
+      );
+    });
+
+    console.log(`Backup completed successfully: ${backupFile}`);
+    
+    // Display backup file size
+    const stats = fs.statSync(backupFile);
+    console.log(`Backup size: ${(stats.size / 1024 / 1024).toFixed(2)} MB`);
+    
+  } catch (error) {
+    console.error('Backup failed:', error.message);
+    process.exit(1);
+  }
+}
+
+// Run backup if called directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  backup();
+}
+
+export { backup };

--- a/scripts/restore.js
+++ b/scripts/restore.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/* eslint-env node */
+
+/**
+ * Basic restore script using @cloudant/couchbackup
+ * Restores CouchDB database from a JSON backup file
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { restore as couchrestore } from '@cloudant/couchbackup';
+
+// Configuration
+const COUCH_URL = process.env.COUCH_URL || 'http://localhost:5984';
+const DATABASE = process.env.DATABASE || 'todos';
+const BACKUP_DIR = process.env.BACKUP_DIR || './backups';
+
+function getLatestBackupFile(database) {
+  if (!fs.existsSync(BACKUP_DIR)) {
+    throw new Error(`Backup directory does not exist: ${BACKUP_DIR}`);
+  }
+
+  const files = fs.readdirSync(BACKUP_DIR)
+    .filter((file) => file.startsWith(`${database}-`) && file.endsWith('.json'))
+    .sort()
+    .reverse();
+
+  if (files.length === 0) {
+    throw new Error(`No backup files found for database: ${database}`);
+  }
+
+  return path.join(BACKUP_DIR, files[0]);
+}
+
+async function restore(backupFile = null) {
+  try {
+    const restoreFile = backupFile || getLatestBackupFile(DATABASE);
+    
+    if (!fs.existsSync(restoreFile)) {
+      throw new Error(`Backup file does not exist: ${restoreFile}`);
+    }
+
+    console.log(`Starting restore of ${DATABASE} database...`);
+    console.log(`Source: ${restoreFile}`);
+    console.log(`Destination: ${COUCH_URL}/${DATABASE}`);
+
+    const readStream = fs.createReadStream(restoreFile);
+    
+    await new Promise((resolve, reject) => {
+      couchrestore(
+        `${COUCH_URL}/${DATABASE}`,
+        readStream,
+        {
+          parallelism: 5,
+          requestTimeout: 60000,
+          logfile: `${restoreFile}.restore.log`
+        },
+        (err, data) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(data);
+          }
+        }
+      );
+    });
+
+    console.log(`Restore completed successfully from: ${restoreFile}`);
+    
+  } catch (error) {
+    console.error('Restore failed:', error.message);
+    process.exit(1);
+  }
+}
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+const backupFile = args.length > 0 ? args[0] : null;
+
+// Run restore if called directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  restore(backupFile);
+}
+
+export { restore };

--- a/scripts/verify-backup.js
+++ b/scripts/verify-backup.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/* eslint-env node */
+
+/**
+ * Backup verification script
+ * Validates backup files and checks data integrity
+ */
+
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+
+// Configuration
+const BACKUP_DIR = process.env.BACKUP_DIR || './backups';
+
+function validateBackupFile(filePath) {
+  console.log(`Validating backup file: ${filePath}`);
+  
+  const stats = fs.statSync(filePath);
+  console.log(`File size: ${(stats.size / 1024 / 1024).toFixed(2)} MB`);
+  
+  if (stats.size === 0) {
+    throw new Error('Backup file is empty');
+  }
+  
+  return new Promise((resolve, reject) => {
+    const fileStream = fs.createReadStream(filePath);
+    const rl = readline.createInterface({
+      input: fileStream,
+      crlfDelay: Infinity
+    });
+    
+    let documentCount = 0;
+    let validDocuments = 0;
+    const errors = [];
+    
+    rl.on('line', (line) => {
+      documentCount++;
+      
+      try {
+        const doc = JSON.parse(line);
+        
+        // Basic validation
+        if (!doc._id) {
+          errors.push(`Line ${documentCount}: Missing _id field`);
+        } else if (doc.version && !['alpha1', 'alpha2', 'alpha3'].includes(doc.version)) {
+          errors.push(`Line ${documentCount}: Invalid version field: ${doc.version}`);
+        } else {
+          validDocuments++;
+        }
+        
+      } catch (parseError) {
+        errors.push(`Line ${documentCount}: Invalid JSON - ${parseError.message}`);
+      }
+    });
+    
+    rl.on('close', () => {
+      const result = {
+        totalDocuments: documentCount,
+        validDocuments,
+        errors,
+        isValid: errors.length === 0 && documentCount > 0
+      };
+      
+      console.log(`Total documents: ${result.totalDocuments}`);
+      console.log(`Valid documents: ${result.validDocuments}`);
+      console.log(`Errors: ${result.errors.length}`);
+      
+      if (result.errors.length > 0) {
+        console.log('Validation errors:');
+        result.errors.forEach((error) => console.log(`  - ${error}`));
+      }
+      
+      resolve(result);
+    });
+    
+    rl.on('error', (error) => {
+      reject(error);
+    });
+  });
+}
+
+async function verifyBackup(backupFile = null) {
+  try {
+    if (backupFile) {
+      // Verify specific file
+      if (!fs.existsSync(backupFile)) {
+        throw new Error(`Backup file does not exist: ${backupFile}`);
+      }
+      
+      const result = await validateBackupFile(backupFile);
+      
+      if (result.isValid) {
+        console.log('✅ Backup file is valid');
+        return true;
+      } else {
+        console.log('❌ Backup file validation failed');
+        return false;
+      }
+    } else {
+      // Verify all backup files in directory
+      if (!fs.existsSync(BACKUP_DIR)) {
+        throw new Error(`Backup directory does not exist: ${BACKUP_DIR}`);
+      }
+      
+      const backupFiles = fs.readdirSync(BACKUP_DIR)
+        .filter((file) => file.endsWith('.json'))
+        .map((file) => path.join(BACKUP_DIR, file));
+      
+      if (backupFiles.length === 0) {
+        throw new Error('No backup files found');
+      }
+      
+      let allValid = true;
+      
+      for (const file of backupFiles) {
+        console.log(`\n--- Verifying ${path.basename(file)} ---`);
+        const result = await validateBackupFile(file);
+        
+        if (!result.isValid) {
+          allValid = false;
+        }
+      }
+      
+      if (allValid) {
+        console.log('\n✅ All backup files are valid');
+        return true;
+      } else {
+        console.log('\n❌ Some backup files have validation errors');
+        return false;
+      }
+    }
+    
+  } catch (error) {
+    console.error('Backup verification failed:', error.message);
+    process.exit(1);
+  }
+}
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+const backupFile = args.length > 0 ? args[0] : null;
+
+// Run verification if called directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  verifyBackup(backupFile);
+}
+
+export { verifyBackup };


### PR DESCRIPTION
## Summary

Implements phase 1 of CouchDB backup/restore functionality as requested in issue #13.

- Adds @cloudant/couchbackup dependency for robust database backup operations
- Creates three Node.js scripts for backup, restore, and verification operations
- Adds corresponding pnpm scripts for easy command-line usage
- Supports environment variable configuration for flexibility

## Features Added

### Backup Script (`scripts/backup.js`)
- Creates timestamped JSON backup files using @cloudant/couchbackup
- Configurable via environment variables (COUCH_URL, DATABASE, BACKUP_DIR)
- Displays backup progress and file size information
- Includes error handling and logging

### Restore Script (`scripts/restore.js`) 
- Restores from latest backup or specified backup file
- Automatically finds most recent backup if no file specified
- Supports command-line argument for specific backup file selection
- Includes validation of backup file existence

### Verification Script (`scripts/verify-backup.js`)
- Validates backup file integrity and JSON structure
- Checks document count and identifies parsing errors
- Validates document structure including version fields (alpha1/alpha2/alpha3)
- Can verify individual files or all backup files in directory

### Package Scripts
- `pnpm backup` - Create database backup
- `pnpm restore` - Restore from latest backup
- `pnpm backup:verify` - Verify backup file integrity

## Technical Implementation

- Uses ES modules (import/export) to match project configuration
- Follows existing code style with functional approach
- Includes comprehensive error handling and user feedback
- Compatible with existing GTD data model (TodoAlpha3)
- Supports versioned data model validation during verification

## Test Plan

- [x] Install @cloudant/couchbackup dependency successfully
- [x] Create backup scripts with proper ES module syntax
- [x] Add pnpm scripts to package.json
- [x] Test verification script with empty backup directory
- [x] Verify all scripts execute without import errors
- [x] Follow project conventions for commit messages and file structure

## Configuration

Scripts use these environment variables with sensible defaults:
- `COUCH_URL` (default: http://localhost:5984)
- `DATABASE` (default: todos)  
- `BACKUP_DIR` (default: ./backups)

Example usage:
```bash
# Basic backup
pnpm backup

# Backup with custom settings
COUCH_URL=http://myserver:5984 DATABASE=mydb pnpm backup

# Restore latest backup
pnpm restore

# Restore specific backup
node scripts/restore.js ./backups/todos-2025-01-15T10-30-00-000Z.json

# Verify all backups
pnpm backup:verify
```

This implements the foundation for the backup/restore system and sets up the infrastructure for phase 2 (automated backups) and phase 3 (recovery tools).