### PR TITLE
refactor: centralize PouchDB change listeners and fix import ordering

### DIFF
--- a/packages/client/src/components/todo_board.tsx
+++ b/packages/client/src/components/todo_board.tsx
@@ -22,6 +22,7 @@ import {
 import { CONTEXT_DEFAULT } from '../constants';
 import { ensureDesignDocuments } from '../database_setup';
 import { usePouchDb } from '../pouch_db';
+import { useDatabaseChanges } from '../hooks/use_database_changes';
 import { DatabaseErrorFallback } from './database_error_fallback';
 import { DatabaseErrorMessage } from './database_error_message';
 import { FormattedMessage } from './formatted_message';
@@ -36,7 +37,8 @@ export const TodoBoard: FC<TodoBoardProps> = ({
   currentDate,
   selectedTags,
 }) => {
-  const { safeDb, changes, rawDb } = usePouchDb();
+  const { safeDb, rawDb } = usePouchDb();
+  const { changeCount } = useDatabaseChanges();
   const [timeTrackingActive, setTimeTrackingActive] = useState<string[]>([
     'hide-by-default',
   ]);
@@ -86,20 +88,9 @@ export const TodoBoard: FC<TodoBoardProps> = ({
   useEffect(() => {
     if (!isInitialized) return;
 
-    const listener = changes({
-      live: true,
-      since: 'now',
-    }).on('change', () => {
-      fetchTodos();
-      fetchTimeTrackingActive();
-    });
-
+    fetchTodos();
     fetchTimeTrackingActive();
-
-    return () => {
-      listener.cancel();
-    };
-  }, [currentDate, isInitialized]);
+  }, [currentDate, isInitialized, changeCount]);
 
   const fetchTimeTrackingActive = useCallback(async () => {
     try {

--- a/packages/client/src/components/todo_board.tsx
+++ b/packages/client/src/components/todo_board.tsx
@@ -21,8 +21,8 @@ import {
 
 import { CONTEXT_DEFAULT } from '../constants';
 import { ensureDesignDocuments } from '../database_setup';
-import { usePouchDb } from '../pouch_db';
 import { useDatabaseChanges } from '../hooks/use_database_changes';
+import { usePouchDb } from '../pouch_db';
 import { DatabaseErrorFallback } from './database_error_fallback';
 import { DatabaseErrorMessage } from './database_error_message';
 import { FormattedMessage } from './formatted_message';

--- a/packages/client/src/eddo.tsx
+++ b/packages/client/src/eddo.tsx
@@ -6,6 +6,7 @@ import { TodoBoard } from './components/todo_board';
 import { useDatabaseHealth } from './hooks/use_database_health';
 import { useSyncDev } from './hooks/use_sync_dev';
 import { PouchDbContext, pouchDbContextValue } from './pouch_db';
+import { DatabaseChangesProvider } from './hooks/use_database_changes';
 
 function DevSync() {
   useSyncDev();
@@ -28,17 +29,19 @@ export function Eddo() {
 
   return (
     <PouchDbContext.Provider value={pouchDbContextValue}>
-      <DevSync />
-      <HealthMonitor />
-      <PageWrapper>
-        <AddTodo
-          currentDate={currentDate}
-          selectedTags={selectedTags}
-          setCurrentDate={setCurrentDate}
-          setSelectedTags={setSelectedTags}
-        />
-        <TodoBoard currentDate={currentDate} selectedTags={selectedTags} />
-      </PageWrapper>
+      <DatabaseChangesProvider>
+        <DevSync />
+        <HealthMonitor />
+        <PageWrapper>
+          <AddTodo
+            currentDate={currentDate}
+            selectedTags={selectedTags}
+            setCurrentDate={setCurrentDate}
+            setSelectedTags={setSelectedTags}
+          />
+          <TodoBoard currentDate={currentDate} selectedTags={selectedTags} />
+        </PageWrapper>
+      </DatabaseChangesProvider>
     </PouchDbContext.Provider>
   );
 }

--- a/packages/client/src/eddo.tsx
+++ b/packages/client/src/eddo.tsx
@@ -3,10 +3,10 @@ import { useEffect, useState } from 'react';
 import { AddTodo } from './components/add_todo';
 import { PageWrapper } from './components/page_wrapper';
 import { TodoBoard } from './components/todo_board';
+import { DatabaseChangesProvider } from './hooks/use_database_changes';
 import { useDatabaseHealth } from './hooks/use_database_health';
 import { useSyncDev } from './hooks/use_sync_dev';
 import { PouchDbContext, pouchDbContextValue } from './pouch_db';
-import { DatabaseChangesProvider } from './hooks/use_database_changes';
 
 function DevSync() {
   useSyncDev();

--- a/packages/client/src/hooks/use_database_changes.tsx
+++ b/packages/client/src/hooks/use_database_changes.tsx
@@ -1,7 +1,14 @@
 /**
  * Database changes provider - single PouchDB listener for the entire app
  */
-import { createContext, useContext, useEffect, useState, type FC, type ReactNode } from 'react';
+import {
+  type FC,
+  type ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 
 import { usePouchDb } from '../pouch_db';
 
@@ -12,12 +19,17 @@ interface DatabaseChangesContextType {
   isListening: boolean;
 }
 
-const DatabaseChangesContext = createContext<DatabaseChangesContextType | null>(null);
+const DatabaseChangesContext = createContext<DatabaseChangesContextType | null>(
+  null,
+);
 
-export const DatabaseChangesProvider: FC<{ children: ReactNode }> = ({ children }) => {
+export const DatabaseChangesProvider: FC<{ children: ReactNode }> = ({
+  children,
+}) => {
   const { changes } = usePouchDb();
   const [changeCount, setChangeCount] = useState(0);
   const [isListening, setIsListening] = useState(false);
+  console.log('changeCount', changeCount);
 
   useEffect(() => {
     const changesListener = changes({
@@ -26,8 +38,8 @@ export const DatabaseChangesProvider: FC<{ children: ReactNode }> = ({ children 
       include_docs: true,
     });
 
-    changesListener.on('change', () => {
-      setChangeCount(prev => prev + 1);
+    changesListener.on('change', (d) => {
+      setChangeCount(Number(d.seq));
     });
 
     changesListener.on('complete', () => {
@@ -61,7 +73,9 @@ export const DatabaseChangesProvider: FC<{ children: ReactNode }> = ({ children 
 export const useDatabaseChanges = (): DatabaseChangesContextType => {
   const context = useContext(DatabaseChangesContext);
   if (!context) {
-    throw new Error('useDatabaseChanges must be used within a DatabaseChangesProvider');
+    throw new Error(
+      'useDatabaseChanges must be used within a DatabaseChangesProvider',
+    );
   }
   return context;
 };

--- a/packages/client/src/hooks/use_database_changes.tsx
+++ b/packages/client/src/hooks/use_database_changes.tsx
@@ -1,0 +1,67 @@
+/**
+ * Database changes provider - single PouchDB listener for the entire app
+ */
+import { createContext, useContext, useEffect, useState, type FC, type ReactNode } from 'react';
+
+import { usePouchDb } from '../pouch_db';
+
+interface DatabaseChangesContextType {
+  /** Increments whenever database changes occur */
+  changeCount: number;
+  /** Whether the changes listener is active */
+  isListening: boolean;
+}
+
+const DatabaseChangesContext = createContext<DatabaseChangesContextType | null>(null);
+
+export const DatabaseChangesProvider: FC<{ children: ReactNode }> = ({ children }) => {
+  const { changes } = usePouchDb();
+  const [changeCount, setChangeCount] = useState(0);
+  const [isListening, setIsListening] = useState(false);
+
+  useEffect(() => {
+    const changesListener = changes({
+      live: true,
+      since: 'now',
+      include_docs: true,
+    });
+
+    changesListener.on('change', () => {
+      setChangeCount(prev => prev + 1);
+    });
+
+    changesListener.on('complete', () => {
+      setIsListening(false);
+    });
+
+    changesListener.on('error', (err) => {
+      console.error('Database changes listener error:', err);
+      setIsListening(false);
+    });
+
+    setIsListening(true);
+
+    return () => {
+      changesListener.cancel();
+      setIsListening(false);
+    };
+  }, [changes]);
+
+  return (
+    <DatabaseChangesContext.Provider value={{ changeCount, isListening }}>
+      {children}
+    </DatabaseChangesContext.Provider>
+  );
+};
+
+/**
+ * Hook to subscribe to database changes
+ * Returns a number that increments whenever the database changes
+ */
+export const useDatabaseChanges = (): DatabaseChangesContextType => {
+  const context = useContext(DatabaseChangesContext);
+  if (!context) {
+    throw new Error('useDatabaseChanges must be used within a DatabaseChangesProvider');
+  }
+  return context;
+};

--- a/packages/client/src/hooks/use_tags.ts
+++ b/packages/client/src/hooks/use_tags.ts
@@ -5,6 +5,7 @@ import { type Todo } from '@eddo/shared';
 import { useEffect, useState } from 'react';
 
 import { usePouchDb } from '../pouch_db';
+import { useDatabaseChanges } from './use_database_changes';
 
 export interface TagsState {
   /** All unique tags from existing todos */
@@ -19,7 +20,8 @@ export interface TagsState {
  * Hook for fetching all existing tags for autocomplete
  */
 export const useTags = (): TagsState => {
-  const { safeDb, changes } = usePouchDb();
+  const { safeDb } = usePouchDb();
+  const { changeCount } = useDatabaseChanges();
   const [allTags, setAllTags] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -54,22 +56,7 @@ export const useTags = (): TagsState => {
     };
 
     fetchTags();
-
-    // Listen for database changes to update tags
-    const changesListener = changes({
-      live: true,
-      since: 'now',
-      include_docs: true,
-    });
-
-    changesListener.on('change', () => {
-      fetchTags();
-    });
-
-    return () => {
-      changesListener.cancel();
-    };
-  }, [safeDb, changes]);
+  }, [safeDb, changeCount]); // Re-fetch when database changes
 
   return {
     allTags,


### PR DESCRIPTION
## Summary
- Centralizes PouchDB change listeners to fix max event listeners warning
- Refactors database change handling with sequence numbers for better change tracking
- Reorders imports following project conventions

## Changes
- Moved all PouchDB change listeners to a centralized `useDatabaseChanges` hook
- Added sequence number tracking for database changes
- Fixed import ordering in affected components
- Removed duplicate change listeners that were causing memory warnings

## Test plan
- [x] Verify no max event listeners warnings in console
- [x] Confirm database changes still trigger proper UI updates
- [x] Test todo operations (create, update, delete) work correctly
- [ ] Verify filtering and context switching still works