### PR TITLE
feat: add basic user authentication to Telegram bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Telegram Bot Configuration
 TELEGRAM_BOT_TOKEN=your_bot_token_from_botfather
+# Comma-separated list of allowed Telegram user IDs (empty = deny all)
+TELEGRAM_ALLOWED_USERS=
 
 # Anthropic API Configuration
 ANTHROPIC_API_KEY=your_anthropic_api_key

--- a/packages/telegram-bot/README.md
+++ b/packages/telegram-bot/README.md
@@ -79,12 +79,18 @@ TELEGRAM_BOT_TOKEN=123456789:ABCdefGHIjklMNOpqrsTUVwxyz
 # From Anthropic Console (Step 2)
 ANTHROPIC_API_KEY=sk-ant-api03-...
 
-# MCP Server (should be running on port 3001, no auth required)
+# MCP Server (should be running on port 3001)
 MCP_SERVER_URL=http://localhost:3001/mcp
+MCP_API_KEY=your-mcp-api-key
 
 # Optional: Adjust logging and environment
 NODE_ENV=development
 LOG_LEVEL=info
+
+# Optional: Restrict bot access to specific users
+# Comma-separated list of Telegram user IDs
+# Leave empty to deny all access (secure by default)
+TELEGRAM_ALLOWED_USERS=123456789,987654321
 ```
 
 ### Step 4: Start the System
@@ -241,13 +247,15 @@ This architecture replaces complex workflow frameworks (like LangGraph) with a m
 
 ### Environment Variables
 
-| Variable             | Description               | Default                 |
-| -------------------- | ------------------------- | ----------------------- |
-| `TELEGRAM_BOT_TOKEN` | Bot token from @BotFather | Required                |
-| `ANTHROPIC_API_KEY`  | Claude API key            | Required                |
-| `MCP_SERVER_URL`     | MCP server endpoint       | `http://localhost:3001` |
-| `NODE_ENV`           | Environment               | `development`           |
-| `LOG_LEVEL`          | Logging level             | `info`                  |
+| Variable                 | Description               | Default                 |
+| ------------------------ | ------------------------- | ----------------------- |
+| `TELEGRAM_BOT_TOKEN`     | Bot token from @BotFather | Required                |
+| `ANTHROPIC_API_KEY`      | Claude API key            | Required                |
+| `MCP_SERVER_URL`         | MCP server endpoint       | `http://localhost:3001` |
+| `MCP_API_KEY`            | MCP server API key        | Required                |
+| `NODE_ENV`               | Environment               | `development`           |
+| `LOG_LEVEL`              | Logging level             | `info`                  |
+| `TELEGRAM_ALLOWED_USERS` | Comma-separated user IDs  | (empty = deny all)      |
 
 ### MCP Server Connection
 
@@ -258,6 +266,33 @@ The bot connects to the MCP server using the official @modelcontextprotocol/sdk 
 - FastMCP server with httpStream transport
 
 The MCP client automatically discovers available tools on startup and provides them to the Claude AI for natural language tool selection.
+
+### User Authentication
+
+The bot implements user authentication to restrict access:
+
+- **Secure by default**: If `TELEGRAM_ALLOWED_USERS` is not set or empty, all users are denied access
+- **Whitelist approach**: Only users whose Telegram ID is in the allowed list can use the bot
+- **Clear rejection messages**: Unauthorized users receive a polite rejection message
+
+To find your Telegram user ID:
+
+1. Start a chat with `@userinfobot` on Telegram
+2. The bot will show your user ID
+3. Add this ID to your `.env` file
+
+Example configuration:
+
+```bash
+# Single user
+TELEGRAM_ALLOWED_USERS=123456789
+
+# Multiple users
+TELEGRAM_ALLOWED_USERS=123456789,987654321,555555555
+
+# Deny all access (default if not set)
+TELEGRAM_ALLOWED_USERS=
+```
 
 ## Deployment
 
@@ -431,13 +466,15 @@ Create and manage your bot:
 
 ### Environment Variables
 
-| Variable             | Required | Description    | Example                     |
-| -------------------- | -------- | -------------- | --------------------------- |
-| `TELEGRAM_BOT_TOKEN` | ✅       | From BotFather | `123456789:ABC...`          |
-| `ANTHROPIC_API_KEY`  | ✅       | Claude AI key  | `sk-ant-api03-...`          |
-| `MCP_SERVER_URL`     | ✅       | MCP endpoint   | `http://localhost:3001/mcp` |
-| `NODE_ENV`           | ⚪       | Environment    | `development`               |
-| `LOG_LEVEL`          | ⚪       | Logging level  | `info`                      |
+| Variable                 | Required | Description    | Example                     |
+| ------------------------ | -------- | -------------- | --------------------------- |
+| `TELEGRAM_BOT_TOKEN`     | ✅       | From BotFather | `123456789:ABC...`          |
+| `ANTHROPIC_API_KEY`      | ✅       | Claude AI key  | `sk-ant-api03-...`          |
+| `MCP_SERVER_URL`         | ✅       | MCP endpoint   | `http://localhost:3001/mcp` |
+| `MCP_API_KEY`            | ✅       | MCP API key    | `your-mcp-api-key`          |
+| `NODE_ENV`               | ⚪       | Environment    | `development`               |
+| `LOG_LEVEL`              | ⚪       | Logging level  | `info`                      |
+| `TELEGRAM_ALLOWED_USERS` | ⚪       | User whitelist | `123456789,987654321`       |
 
 ### Service Dependencies
 

--- a/packages/telegram-bot/src/bot/bot.ts
+++ b/packages/telegram-bot/src/bot/bot.ts
@@ -2,6 +2,7 @@ import { Bot, Context, session } from 'grammy';
 
 import { appConfig } from '../utils/config.js';
 import { logger } from '../utils/logger.js';
+import { authMiddleware } from './middleware/auth.js';
 
 // Define session data structure
 interface SessionData {
@@ -33,6 +34,9 @@ export function createBot(): Bot<BotContext> {
       }),
     }),
   );
+
+  // Add authentication middleware
+  bot.use(authMiddleware);
 
   // Add logging middleware
   bot.use(async (ctx, next) => {

--- a/packages/telegram-bot/src/bot/middleware/auth.test.ts
+++ b/packages/telegram-bot/src/bot/middleware/auth.test.ts
@@ -3,12 +3,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { authMiddleware, isUserAuthorized } from './auth';
 
-// Mock the allowedUsers
-const mockAllowedUsers = new Set<number>();
-vi.mock('../../utils/config', () => ({
-  allowedUsers: mockAllowedUsers,
-  appConfig: {} as unknown,
-}));
+// Mock the config module before importing anything that uses it
+vi.mock('../../utils/config', () => {
+  const mockAllowedUsers = new Set<number>();
+  return {
+    allowedUsers: mockAllowedUsers,
+    appConfig: {} as unknown,
+  };
+});
+
+// Get reference to the mocked allowedUsers after the mock is set up
+const { allowedUsers: mockAllowedUsers } = await import('../../utils/config');
 
 describe('Authentication Middleware', () => {
   let nextMock: ReturnType<typeof vi.fn<[], Promise<void>>>;

--- a/packages/telegram-bot/src/bot/middleware/auth.test.ts
+++ b/packages/telegram-bot/src/bot/middleware/auth.test.ts
@@ -1,0 +1,94 @@
+import { Context } from 'grammy';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { authMiddleware, isUserAuthorized } from './auth';
+
+// Mock the allowedUsers
+const mockAllowedUsers = new Set<number>();
+vi.mock('../../utils/config', () => ({
+  allowedUsers: mockAllowedUsers,
+  appConfig: {} as unknown,
+}));
+
+describe('Authentication Middleware', () => {
+  let nextMock: ReturnType<typeof vi.fn<[], Promise<void>>>;
+
+  beforeEach(() => {
+    nextMock = vi.fn<[], Promise<void>>();
+  });
+
+  function createMockContext(userId?: number): Context {
+    return {
+      from: userId ? { id: userId } : undefined,
+      reply: vi.fn(),
+    } as unknown as Context;
+  }
+
+  describe('isUserAuthorized', () => {
+    it('should return false when no users are configured', () => {
+      mockAllowedUsers.clear();
+      expect(isUserAuthorized(123456789)).toBe(false);
+    });
+
+    it('should return true for authorized users', () => {
+      mockAllowedUsers.clear();
+      mockAllowedUsers.add(123456789);
+      mockAllowedUsers.add(987654321);
+      expect(isUserAuthorized(123456789)).toBe(true);
+      expect(isUserAuthorized(987654321)).toBe(true);
+    });
+
+    it('should return false for unauthorized users', () => {
+      mockAllowedUsers.clear();
+      mockAllowedUsers.add(123456789);
+      expect(isUserAuthorized(555555555)).toBe(false);
+    });
+  });
+
+  describe('authMiddleware', () => {
+    it('should reject when user ID is not available', async () => {
+      const mockCtx = createMockContext();
+      await authMiddleware(mockCtx, nextMock);
+
+      expect(mockCtx.reply).toHaveBeenCalledWith(
+        '❌ Unable to verify your identity. Please try again.',
+      );
+      expect(nextMock).not.toHaveBeenCalled();
+    });
+
+    it('should reject unauthorized users', async () => {
+      mockAllowedUsers.clear();
+      mockAllowedUsers.add(987654321);
+      const mockCtx = createMockContext(123456789);
+      await authMiddleware(mockCtx, nextMock);
+
+      expect(mockCtx.reply).toHaveBeenCalledWith(
+        '🚫 Unauthorized: You are not allowed to use this bot.\n\n' +
+          'If you believe this is an error, please contact the bot administrator.',
+      );
+      expect(nextMock).not.toHaveBeenCalled();
+    });
+
+    it('should allow authorized users', async () => {
+      mockAllowedUsers.clear();
+      mockAllowedUsers.add(123456789);
+      const mockCtx = createMockContext(123456789);
+      await authMiddleware(mockCtx, nextMock);
+
+      expect(mockCtx.reply).not.toHaveBeenCalled();
+      expect(nextMock).toHaveBeenCalled();
+    });
+
+    it('should deny all users when allowedUsers is empty', async () => {
+      mockAllowedUsers.clear();
+      const mockCtx = createMockContext(123456789);
+      await authMiddleware(mockCtx, nextMock);
+
+      expect(mockCtx.reply).toHaveBeenCalledWith(
+        '🚫 Unauthorized: You are not allowed to use this bot.\n\n' +
+          'If you believe this is an error, please contact the bot administrator.',
+      );
+      expect(nextMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/telegram-bot/src/bot/middleware/auth.ts
+++ b/packages/telegram-bot/src/bot/middleware/auth.ts
@@ -1,6 +1,7 @@
 import { Context } from 'grammy';
 
 import { allowedUsers } from '../../utils/config';
+import { logger } from '../../utils/logger';
 
 export function isUserAuthorized(userId: number): boolean {
   // If no users are configured, deny all access for security
@@ -16,13 +17,28 @@ export async function authMiddleware(
   next: () => Promise<void>,
 ): Promise<void> {
   const userId = ctx.from?.id;
+  const username = ctx.from?.username;
 
   if (!userId) {
+    logger.warn('Authentication failed: No user ID available', {
+      chat: ctx.chat?.id,
+      messageText: ctx.message?.text,
+    });
     await ctx.reply('❌ Unable to verify your identity. Please try again.');
     return;
   }
 
   if (!isUserAuthorized(userId)) {
+    logger.warn('Unauthorized access attempt', {
+      userId,
+      username,
+      firstName: ctx.from?.first_name,
+      lastName: ctx.from?.last_name,
+      chatId: ctx.chat?.id,
+      messageText: ctx.message?.text,
+      allowedUsersCount: allowedUsers.size,
+    });
+
     await ctx.reply(
       '🚫 Unauthorized: You are not allowed to use this bot.\n\n' +
         'If you believe this is an error, please contact the bot administrator.',

--- a/packages/telegram-bot/src/bot/middleware/auth.ts
+++ b/packages/telegram-bot/src/bot/middleware/auth.ts
@@ -1,0 +1,35 @@
+import { Context } from 'grammy';
+
+import { allowedUsers } from '../../utils/config';
+
+export function isUserAuthorized(userId: number): boolean {
+  // If no users are configured, deny all access for security
+  if (allowedUsers.size === 0) {
+    return false;
+  }
+
+  return allowedUsers.has(userId);
+}
+
+export async function authMiddleware(
+  ctx: Context,
+  next: () => Promise<void>,
+): Promise<void> {
+  const userId = ctx.from?.id;
+
+  if (!userId) {
+    await ctx.reply('❌ Unable to verify your identity. Please try again.');
+    return;
+  }
+
+  if (!isUserAuthorized(userId)) {
+    await ctx.reply(
+      '🚫 Unauthorized: You are not allowed to use this bot.\n\n' +
+        'If you believe this is an error, please contact the bot administrator.',
+    );
+    return;
+  }
+
+  // User is authorized, proceed to next middleware/handler
+  await next();
+}

--- a/packages/telegram-bot/src/utils/config.ts
+++ b/packages/telegram-bot/src/utils/config.ts
@@ -12,6 +12,7 @@ const TelegramConfigSchema = z.object({
   MCP_API_KEY: z
     .string()
     .min(1, 'MCP API key is required for server authentication'),
+  TELEGRAM_ALLOWED_USERS: z.string().optional(),
 });
 
 // Type for telegram-specific config
@@ -35,6 +36,24 @@ try {
   console.error('Configuration validation failed:', error);
   process.exit(1);
 }
+
+// Parse allowed users from comma-separated string
+function parseAllowedUsers(allowedUsersString?: string): Set<number> {
+  if (!allowedUsersString || allowedUsersString.trim() === '') {
+    return new Set();
+  }
+
+  return new Set(
+    allowedUsersString
+      .split(',')
+      .map((id) => id.trim())
+      .filter((id) => id !== '')
+      .map((id) => parseInt(id, 10))
+      .filter((id) => !isNaN(id)),
+  );
+}
+
+export const allowedUsers = parseAllowedUsers(appConfig.TELEGRAM_ALLOWED_USERS);
 
 export { appConfig };
 export type { Config };


### PR DESCRIPTION
## Summary
- Implements Phase 1 of the Telegram bot security improvements (issue #67)
- Adds TELEGRAM_ALLOWED_USERS environment variable for user whitelist authentication
- Creates authentication middleware that runs before all bot interactions
- Secure by default: denies all access if no users are configured

## Changes Made
- Added TELEGRAM_ALLOWED_USERS environment variable parsing to config
- Created authentication middleware in packages/telegram-bot/src/bot/middleware/auth.ts  
- Integrated middleware into bot instance creation
- Added comprehensive tests for authentication logic
- Updated documentation with authentication configuration
- Added detailed logging for unauthorized access attempts

## Security Features
- Whitelist-based user authentication using Telegram user IDs
- Secure by default behavior (empty config = deny all)
- Clear rejection messages for unauthorized users
- Comprehensive logging of unauthorized access attempts with user details
- Rate limiting still applies after authentication

## Testing
- All existing tests pass
- New authentication middleware tests cover all scenarios
- Manual testing verified with actual Telegram user IDs

## Configuration
```bash
# Allow specific users
TELEGRAM_ALLOWED_USERS=123456789,987654321

# Deny all access (default/secure)
TELEGRAM_ALLOWED_USERS=
```