### PR TITLE
feat: enhance MCP tool descriptions and parameter guidance

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,3 +1,3 @@
 git commit just the currently staged files with a proper one-liner commit message. it must be a one-liner without any credit information like "generated with" or "co-authored by".
 
-Note: Husky pre-commit hook runs TypeScript checks, linting, and format checks. If the hook finds problems, fix them before attempting to commit again. Don't forget to stage the files you make changes to when fixing pre-commit issues.
+Note: Husky pre-commit hook runs TypeScript checks, linting, and format checks. If the hook finds problems, fix them before attempting to commit again. Don't forget to stage the files you make changes to when fixing pre-commit issues. NEVER stage files that were not part of the originally staged files. NEVER git add to bulk stage files.

--- a/dev/MCP-CRUD-PROMPTS.md
+++ b/dev/MCP-CRUD-PROMPTS.md
@@ -38,44 +38,44 @@ Which todos currently have active time tracking?
 
 ### Todo Modifications
 ```
-Update the todo with ID "2025-06-18T10:30:00.000Z" to have title "Updated Title" and description "New description"
+Update the todo "Test MCP Create" to have title "Updated Title" and description "New description"
 
-Change the todo "2025-06-18T10:30:00.000Z" to private context and due date June 30th, 2025
+Change the todo "Complex Todo" to private context and due date June 30th, 2025
 
-Add tags "updated" and "mcp-test" to todo "2025-06-18T10:30:00.000Z" and set its link to "https://updated-link.com"
+Add tags "updated" and "mcp-test" to todo "Test MCP Create" and set its link to "https://updated-link.com"
 
-Mark todo "2025-06-18T10:30:00.000Z" as completed
+Mark todo "Test MCP Create" as completed
 
-Mark todo "2025-06-18T10:30:00.000Z" as incomplete again
+Mark todo "Updated Title" as incomplete again
 ```
 
 ## DELETE Operations
 
 ### Todo Removal
 ```
-Delete the todo with ID "2025-06-18T10:30:00.000Z"
+Delete the todo "Test MCP Create"
 
-Remove todo "2025-06-18T10:30:00.000Z" and then show me remaining work todos
+Remove todo "Complex Todo" and then show me remaining work todos
 ```
 
 ## TIME TRACKING Operations
 
 ### Start/Stop Time Tracking
 ```
-Start tracking time on todo "2025-06-18T10:30:00.000Z" under "development" category
+Start tracking time on todo "Test MCP Create" under "development" category
 
 Show me which todos have active time tracking
 
-Stop time tracking for "development" category on todo "2025-06-18T10:30:00.000Z"
+Stop time tracking for "development" category on todo "Test MCP Create"
 
-Start time tracking on todo "2025-06-18T10:30:00.000Z" for both "research" and "testing" categories
+Start time tracking on todo "Complex Todo" for both "research" and "testing" categories
 ```
 
 ## ERROR HANDLING Tests
 
 ### Invalid Input Testing
 ```
-Try to update a todo with invalid ID "invalid-id" to title "Should fail"
+Try to update a todo called "Nonexistent Todo" to title "Should fail"
 
 Create a todo for work context without specifying a title
 

--- a/packages/server/src/mcp-server.ts
+++ b/packages/server/src/mcp-server.ts
@@ -109,13 +109,16 @@ server.addTool({
   name: 'createTodo',
   description: `Create a new todo item in the authenticated user's database.
 
-    Creates a TodoAlpha3 object with:
-    - Auto-generated ID (current ISO timestamp)
-    - Empty time tracking (active: {})
-    - Not completed status (completed: null)
-    - Default due date of end of current day if not specified
+Creates a TodoAlpha3 object with:
+- Auto-generated ID (current ISO timestamp)
+- Empty time tracking (active: {})
+- Not completed status (completed: null)
+- Default due date of end of current day if not specified
 
-    Returns: "Todo created with ID: <generated-id>"`,
+Usage examples:
+- Simple todo: {"title": "Buy groceries"}
+- With context: {"title": "Review budget", "context": "work", "due": "2025-07-15T23:59:59.999Z"}
+- With tags: {"title": "Call dentist", "context": "private", "tags": ["health", "urgent"]}`,
   parameters: z.object({
     title: z
       .string()
@@ -247,8 +250,14 @@ server.addTool({
 // List Todos Tool
 server.addTool({
   name: 'listTodos',
-  description:
-    "List todos with optional filters from the authenticated user's database. Available filters: context (GTD context), completed (boolean), dateFrom/dateTo (ISO date strings for due date range), limit (number of results)",
+  description: `List todos with optional filters from the authenticated user's database. Available filters: context (GTD context), completed (boolean), dateFrom/dateTo (ISO date strings for due date range), limit (number of results)
+
+Usage examples:
+- All todos: {}
+- Work todos: {"context": "work"}
+- Incomplete todos: {"completed": false}
+- This week's todos: {"dateFrom": "2025-07-10T00:00:00.000Z", "dateTo": "2025-07-16T23:59:59.999Z"}
+- Combined filters: {"context": "work", "completed": false, "limit": 10}`,
   parameters: z.object({
     context: z
       .string()
@@ -446,8 +455,14 @@ server.addTool({
 // Update Todo Tool
 server.addTool({
   name: 'updateTodo',
-  description:
-    'Update an existing todo CouchDB style. Before doing this update, you need to find the todo using listTodos to determine the ID.',
+  description: `Update an existing todo CouchDB style. Before doing this update, you need to find the todo using listTodos to determine the ID.
+
+Usage examples:
+- Update title: {"id": "2025-07-10T20:35:54.935Z", "title": "New title"}
+- Update multiple fields: {"id": "2025-07-10T20:35:54.935Z", "title": "New title", "description": "Updated notes", "context": "work"}
+- Update due date: {"id": "2025-07-10T20:35:54.935Z", "due": "2025-07-15T23:59:59.999Z"}
+
+IMPORTANT: Pass update fields directly as parameters, NOT wrapped in nested objects.`,
   parameters: z.object({
     id: z
       .string()

--- a/packages/server/src/mcp-server.ts
+++ b/packages/server/src/mcp-server.ts
@@ -248,7 +248,7 @@ server.addTool({
 server.addTool({
   name: 'listTodos',
   description:
-    "List todos with optional filters from the authenticated user's database",
+    "List todos with optional filters from the authenticated user's database. Available filters: context (GTD context), completed (boolean), dateFrom/dateTo (ISO date strings for due date range), limit (number of results)",
   parameters: z.object({
     context: z
       .string()

--- a/packages/telegram-bot/src/agent/system-prompt.ts
+++ b/packages/telegram-bot/src/agent/system-prompt.ts
@@ -53,6 +53,14 @@ ${toolDescriptions}
 To use a tool, respond with: TOOL_CALL: {"name": "toolName", "parameters": {...}}
 Always prefix a tool call with a brief conversational contextual message
 
+CRITICAL: Follow each tool's parameter schema EXACTLY as defined. Each tool description includes usage examples showing the correct parameter format. Study the examples carefully and replicate the exact structure.
+
+MCP Tool Usage Rules:
+- Pass parameters directly as specified in the tool's inputSchema
+- Do NOT wrap parameters in nested objects unless explicitly required
+- Use the exact parameter names and types shown in tool descriptions
+- Follow the usage examples provided by each tool
+
 CRITICAL: Execute tools ONE AT A TIME. After making a tool call:
 1. STOP your response immediately
 2. WAIT for the tool execution result

--- a/scripts/test-mcp.js
+++ b/scripts/test-mcp.js
@@ -123,15 +123,15 @@ READ:
   pnpm test:mcp getActiveTimeTracking '{}'
 
 UPDATE:
-  pnpm test:mcp updateTodo '{"id": "2025-06-18T10:30:00.000Z", "updates": {"title": "New Title"}}'
-  pnpm test:mcp toggleTodoCompletion '{"id": "2025-06-18T10:30:00.000Z"}'
+  pnpm test:mcp updateTodo '{"id": "2025-06-18T10:30:00.000Z", "title": "New Title"}'
+  pnpm test:mcp toggleTodoCompletion '{"id": "2025-06-18T10:30:00.000Z", "completed": true}'
 
 DELETE:
   pnpm test:mcp deleteTodo '{"id": "2025-06-18T10:30:00.000Z"}'
 
 TIME TRACKING:
-  pnpm test:mcp startTimeTracking '{"id": "2025-06-18T10:30:00.000Z", "category": "development"}'
-  pnpm test:mcp stopTimeTracking '{"id": "2025-06-18T10:30:00.000Z", "category": "development"}'
+  pnpm test:mcp startTimeTracking '{"id": "2025-06-18T10:30:00.000Z"}'
+  pnpm test:mcp stopTimeTracking '{"id": "2025-06-18T10:30:00.000Z"}'
 
 OTHER:
   pnpm test:mcp getServerInfo '{"section": "all"}'


### PR DESCRIPTION
## Summary
- Enhanced MCP tool descriptions with usage examples and parameter guidance
- Updated test prompts to use titles instead of IDs for better usability
- Improved system prompt to clarify tool parameter requirements

## Changes
- Added usage examples to `createTodo`, `listTodos`, and `updateTodo` tools
- Updated MCP test prompts to use todo titles instead of IDs
- Enhanced telegram bot system prompt with critical tool usage rules
- Fixed test script examples to use correct parameter format

## Test plan
- [x] Verify MCP tools work correctly with updated descriptions
- [x] Test telegram bot agent with improved parameter guidance
- [x] Validate test prompts work with title-based references