### PR TITLE
Migrate time tracking to TanStack Query

### DIFF
--- a/.changeset/tanstack-query-time-tracking.md
+++ b/.changeset/tanstack-query-time-tracking.md
@@ -1,0 +1,5 @@
+---
+'@eddo/web-client': patch
+---
+
+Migrate time tracking data fetching to TanStack Query for consistency

--- a/packages/web-client/src/hooks/use_time_tracking_active.test.ts
+++ b/packages/web-client/src/hooks/use_time_tracking_active.test.ts
@@ -1,0 +1,198 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { type ReactNode, createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { usePouchDb } from '../pouch_db';
+import { useTimeTrackingActive } from './use_time_tracking_active';
+
+// Mock the usePouchDb hook
+vi.mock('../pouch_db', () => ({
+  usePouchDb: vi.fn(),
+}));
+
+describe('useTimeTrackingActive', () => {
+  let queryClient: QueryClient;
+  let mockSafeDb: {
+    safeQuery: ReturnType<typeof vi.fn>;
+    safeGet: ReturnType<typeof vi.fn>;
+    safePut: ReturnType<typeof vi.fn>;
+    safeRemove: ReturnType<typeof vi.fn>;
+    safeAllDocs: ReturnType<typeof vi.fn>;
+    safeBulkDocs: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    // Create fresh query client for each test
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false, // Disable retries in tests
+        },
+      },
+    });
+
+    // Create mock safeDb with all required methods
+    mockSafeDb = {
+      safeQuery: vi.fn(),
+      safeGet: vi.fn(),
+      safePut: vi.fn(),
+      safeRemove: vi.fn(),
+      safeAllDocs: vi.fn(),
+      safeBulkDocs: vi.fn(),
+    };
+
+    // Mock usePouchDb to return our mock safeDb
+    vi.mocked(usePouchDb).mockReturnValue({
+      safeDb: mockSafeDb as never,
+      rawDb: null as never,
+      changes: vi.fn() as never,
+      sync: null as never,
+      healthMonitor: null as never,
+    });
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+
+  it('should return expected data structure (array of IDs)', async () => {
+    const mockIds = [{ id: 'todo-1' }, { id: 'todo-2' }, { id: 'todo-3' }];
+
+    mockSafeDb.safeQuery.mockResolvedValue(mockIds);
+
+    const { result } = renderHook(() => useTimeTrackingActive(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(['todo-1', 'todo-2', 'todo-3']);
+  });
+
+  it('should respect enabled parameter when false', () => {
+    const { result } = renderHook(
+      () => useTimeTrackingActive({ enabled: false }),
+      { wrapper },
+    );
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockSafeDb.safeQuery).not.toHaveBeenCalled();
+  });
+
+  it('should respect enabled parameter when true', async () => {
+    mockSafeDb.safeQuery.mockResolvedValue([{ id: 'todo-1' }]);
+
+    const { result } = renderHook(
+      () => useTimeTrackingActive({ enabled: true }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockSafeDb.safeQuery).toHaveBeenCalled();
+    expect(result.current.data).toEqual(['todo-1']);
+  });
+
+  it('should use correct query key structure', async () => {
+    mockSafeDb.safeQuery.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useTimeTrackingActive(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Check that the query is cached with the correct key
+    const cache = queryClient.getQueryCache();
+    const queries = cache.findAll({
+      queryKey: ['todos', 'byTimeTrackingActive'],
+    });
+
+    expect(queries.length).toBe(1);
+  });
+
+  it('should call safeQuery with correct parameters', async () => {
+    mockSafeDb.safeQuery.mockResolvedValue([]);
+
+    renderHook(() => useTimeTrackingActive(), { wrapper });
+
+    await waitFor(() =>
+      expect(mockSafeDb.safeQuery).toHaveBeenCalledWith(
+        'todos',
+        'byTimeTrackingActive',
+        {
+          key: null,
+        },
+      ),
+    );
+  });
+
+  it('should return empty array when no active time tracking', async () => {
+    mockSafeDb.safeQuery.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useTimeTrackingActive(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('should handle single active time tracking entry', async () => {
+    mockSafeDb.safeQuery.mockResolvedValue([{ id: 'single-todo' }]);
+
+    const { result } = renderHook(() => useTimeTrackingActive(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(['single-todo']);
+  });
+
+  it('should handle errors gracefully', async () => {
+    const error = new Error('Database error');
+    mockSafeDb.safeQuery.mockRejectedValue(error);
+
+    const { result } = renderHook(() => useTimeTrackingActive(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toEqual(error);
+  });
+
+  it('should not query when safeDb is null', () => {
+    vi.mocked(usePouchDb).mockReturnValue({
+      safeDb: null as never,
+      rawDb: null as never,
+      changes: vi.fn() as never,
+      sync: null as never,
+      healthMonitor: null as never,
+    });
+
+    const { result } = renderHook(() => useTimeTrackingActive(), {
+      wrapper,
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockSafeDb.safeQuery).not.toHaveBeenCalled();
+  });
+
+  it('should provide loading state', () => {
+    mockSafeDb.safeQuery.mockImplementation(
+      () => new Promise(() => {}), // Never resolves
+    );
+
+    const { result } = renderHook(() => useTimeTrackingActive(), {
+      wrapper,
+    });
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/packages/web-client/src/hooks/use_time_tracking_active.ts
+++ b/packages/web-client/src/hooks/use_time_tracking_active.ts
@@ -1,0 +1,41 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { usePouchDb } from '../pouch_db';
+
+interface UseTimeTrackingActiveParams {
+  enabled?: boolean;
+}
+
+/**
+ * Custom hook to fetch currently active time tracking entries using TanStack Query.
+ *
+ * This hook uses TanStack Query for caching and state management, while
+ * relying on PouchDB changes feed (via DatabaseChangesProvider) for
+ * real-time invalidation.
+ *
+ * @param enabled - Whether the query should run (default: true if safeDb exists)
+ * @returns TanStack Query result with active todo IDs, loading, and error states
+ */
+export function useTimeTrackingActive({
+  enabled = true,
+}: UseTimeTrackingActiveParams = {}) {
+  const { safeDb } = usePouchDb();
+
+  return useQuery({
+    queryKey: ['todos', 'byTimeTrackingActive'],
+    queryFn: async () => {
+      console.time('fetchTimeTrackingActive');
+      const results = await safeDb.safeQuery<{ id: string }>(
+        'todos',
+        'byTimeTrackingActive',
+        {
+          key: null,
+        },
+      );
+      const ids = results.map((d) => d.id);
+      console.timeEnd('fetchTimeTrackingActive');
+      return ids;
+    },
+    enabled: !!safeDb && enabled,
+  });
+}

--- a/spec/todos/done/2025-10-05-16-56-36-tanstack-query-time-tracking.md
+++ b/spec/todos/done/2025-10-05-16-56-36-tanstack-query-time-tracking.md
@@ -1,6 +1,6 @@
 # in todo_board.tsx use tanstack query for fetchTimeTrackingActive similar with todo and activities.
 
-**Status:** In Progress
+**Status:** Done
 **Created:** 2025-10-05T16:56:36
 **Started:** 2025-10-05T16:58:00
 **Agent PID:** 81503
@@ -33,12 +33,12 @@ in todo_board.tsx use tanstack query for fetchTimeTrackingActive similar with to
 
 ## Success Criteria
 
-- [ ] Functional: New `useTimeTrackingActive` hook returns same data structure as current implementation (array of todo IDs)
-- [ ] Functional: Active time tracking IDs automatically update when todos change (via existing PouchDB changes feed)
-- [ ] Functional: Time tracking highlights in UI work identically to current behavior
-- [ ] Code quality: Hook follows same pattern as `useTodosByWeek` and `useActivitiesByWeek` (query key structure, enabled parameter, performance timing)
-- [ ] Code quality: All manual state management removed from `todo_board.tsx` (no `useState` for `timeTrackingActive`, no `useCallback` for fetch function)
-- [ ] User validation: Manual test confirms time tracking highlights update in real-time when starting/stopping time tracking on a todo
+- [x] Functional: New `useTimeTrackingActive` hook returns same data structure as current implementation (array of todo IDs)
+- [x] Functional: Active time tracking IDs automatically update when todos change (via existing PouchDB changes feed)
+- [x] Functional: Time tracking highlights in UI work identically to current behavior
+- [x] Code quality: Hook follows same pattern as `useTodosByWeek` and `useActivitiesByWeek` (query key structure, enabled parameter, performance timing)
+- [x] Code quality: All manual state management removed from `todo_board.tsx` (no `useState` for `timeTrackingActive`, no `useCallback` for fetch function)
+- [x] User validation: Manual test confirms time tracking highlights update in real-time when starting/stopping time tracking on a todo
 
 ## Implementation Plan
 
@@ -60,6 +60,6 @@ in todo_board.tsx use tanstack query for fetchTimeTrackingActive similar with to
 
 ### User Tests
 
-- [ ] User test: Start time tracking on a todo and verify it gets highlighted in the UI
-- [ ] User test: Stop time tracking and verify highlight is removed
-- [ ] User test: Verify multiple todos can have active time tracking simultaneously
+- [x] User test: Start time tracking on a todo and verify it gets highlighted in the UI
+- [x] User test: Stop time tracking and verify highlight is removed
+- [x] User test: Verify multiple todos can have active time tracking simultaneously

--- a/spec/todos/work/2025-10-05-16-56-36-tanstack-query-time-tracking/task.md
+++ b/spec/todos/work/2025-10-05-16-56-36-tanstack-query-time-tracking/task.md
@@ -1,0 +1,64 @@
+# in todo_board.tsx use tanstack query for fetchTimeTrackingActive similar with todo and activities.
+
+**Status:** Refining
+**Created:** 2025-10-05T16:56:36
+**Agent PID:** 81503
+
+## Original Todo
+
+in todo_board.tsx use tanstack query for fetchTimeTrackingActive similar with todo and activities.
+
+## Description
+
+**Current State:**
+
+- `todo_board.tsx` currently uses a manual `fetchTimeTrackingActive` function with `useCallback` and local state
+- It fetches active time tracking IDs once on initialization using a direct PouchDB query
+- This data won't automatically update when database changes occur
+
+**Desired State:**
+
+- Migrate `fetchTimeTrackingActive` to use TanStack Query pattern, matching the existing `useTodosByWeek` and `useActivitiesByWeek` hooks
+- Create a new `useTimeTrackingActive` hook following the established pattern
+- Replace manual state management with TanStack Query's caching and automatic invalidation
+- Ensure real-time updates through the existing PouchDB changes feed integration
+
+**Benefits:**
+
+- Consistency with existing query patterns in the codebase
+- Automatic cache invalidation when todos change (already handled by `DatabaseChangesProvider`)
+- Built-in loading and error states from TanStack Query
+- Better developer experience with unified data fetching approach
+
+## Success Criteria
+
+- [ ] Functional: New `useTimeTrackingActive` hook returns same data structure as current implementation (array of todo IDs)
+- [ ] Functional: Active time tracking IDs automatically update when todos change (via existing PouchDB changes feed)
+- [ ] Functional: Time tracking highlights in UI work identically to current behavior
+- [ ] Code quality: Hook follows same pattern as `useTodosByWeek` and `useActivitiesByWeek` (query key structure, enabled parameter, performance timing)
+- [ ] Code quality: All manual state management removed from `todo_board.tsx` (no `useState` for `timeTrackingActive`, no `useCallback` for fetch function)
+- [ ] User validation: Manual test confirms time tracking highlights update in real-time when starting/stopping time tracking on a todo
+
+## Implementation Plan
+
+### Code Modifications
+
+- [ ] Create new hook file `packages/web-client/src/hooks/use_time_tracking_active.ts` with TanStack Query pattern
+- [ ] Update `packages/web-client/src/components/todo_board.tsx` to:
+  - Import and use `useTimeTrackingActive` hook
+  - Replace `timeTrackingActive` state with query result
+  - Remove `fetchTimeTrackingActive` callback function
+  - Remove `useEffect` that calls `fetchTimeTrackingActive`
+  - Update component to use `timeTrackingQuery.data` with fallback to `['hide-by-default']`
+
+### Automated Tests
+
+- [ ] Automated test: Verify `useTimeTrackingActive` hook returns expected data structure (array of IDs)
+- [ ] Automated test: Verify hook respects `enabled` parameter
+- [ ] Automated test: Verify query key structure matches pattern (`['todos', 'byTimeTrackingActive']`)
+
+### User Tests
+
+- [ ] User test: Start time tracking on a todo and verify it gets highlighted in the UI
+- [ ] User test: Stop time tracking and verify highlight is removed
+- [ ] User test: Verify multiple todos can have active time tracking simultaneously

--- a/spec/todos/work/2025-10-05-16-56-36-tanstack-query-time-tracking/task.md
+++ b/spec/todos/work/2025-10-05-16-56-36-tanstack-query-time-tracking/task.md
@@ -1,7 +1,8 @@
 # in todo_board.tsx use tanstack query for fetchTimeTrackingActive similar with todo and activities.
 
-**Status:** Refining
+**Status:** In Progress
 **Created:** 2025-10-05T16:56:36
+**Started:** 2025-10-05T16:58:00
 **Agent PID:** 81503
 
 ## Original Todo
@@ -43,8 +44,8 @@ in todo_board.tsx use tanstack query for fetchTimeTrackingActive similar with to
 
 ### Code Modifications
 
-- [ ] Create new hook file `packages/web-client/src/hooks/use_time_tracking_active.ts` with TanStack Query pattern
-- [ ] Update `packages/web-client/src/components/todo_board.tsx` to:
+- [x] Create new hook file `packages/web-client/src/hooks/use_time_tracking_active.ts` with TanStack Query pattern (packages/web-client/src/hooks/use_time_tracking_active.ts)
+- [x] Update `packages/web-client/src/components/todo_board.tsx` to: (packages/web-client/src/components/todo_board.tsx:16,60-72,331-333)
   - Import and use `useTimeTrackingActive` hook
   - Replace `timeTrackingActive` state with query result
   - Remove `fetchTimeTrackingActive` callback function
@@ -53,9 +54,9 @@ in todo_board.tsx use tanstack query for fetchTimeTrackingActive similar with to
 
 ### Automated Tests
 
-- [ ] Automated test: Verify `useTimeTrackingActive` hook returns expected data structure (array of IDs)
-- [ ] Automated test: Verify hook respects `enabled` parameter
-- [ ] Automated test: Verify query key structure matches pattern (`['todos', 'byTimeTrackingActive']`)
+- [x] Automated test: Verify `useTimeTrackingActive` hook returns expected data structure (array of IDs) (packages/web-client/src/hooks/use_time_tracking_active.test.ts:46-56)
+- [x] Automated test: Verify hook respects `enabled` parameter (packages/web-client/src/hooks/use_time_tracking_active.test.ts:58-69,71-82)
+- [x] Automated test: Verify query key structure matches pattern (`['todos', 'byTimeTrackingActive']`) (packages/web-client/src/hooks/use_time_tracking_active.test.ts:84-98)
 
 ### User Tests
 


### PR DESCRIPTION
## Summary

- Created `useTimeTrackingActive` hook using TanStack Query pattern
- Refactored `todo_board.tsx` to use the new hook instead of manual state management
- Removed `useState`, `useCallback`, and `useEffect` for time tracking data fetching
- Added comprehensive test coverage for the new hook
- Maintains real-time updates via existing PouchDB changes feed integration

## Changes

- New hook: `packages/web-client/src/hooks/use_time_tracking_active.ts`
- New tests: `packages/web-client/src/hooks/use_time_tracking_active.test.ts`
- Updated: `packages/web-client/src/components/todo_board.tsx`
- Changeset: `.changeset/tanstack-query-time-tracking.md`

## Benefits

- Consistency with existing `useTodosByWeek` and `useActivitiesByWeek` patterns
- Automatic cache invalidation through `DatabaseChangesProvider`
- Built-in loading and error states from TanStack Query
- Simplified component logic

## Test Plan

- [x] Unit tests pass for `useTimeTrackingActive` hook
- [x] Manual test: Start time tracking on a todo - verified highlight appears
- [x] Manual test: Stop time tracking - verified highlight is removed
- [x] Manual test: Multiple active time tracking entries work simultaneously