### PR TITLE
refactor: split design docs into separate documents

### DIFF
--- a/.changeset/split-design-documents.md
+++ b/.changeset/split-design-documents.md
@@ -1,0 +1,6 @@
+---
+'@eddo/core-shared': patch
+'@eddo/web-client': patch
+---
+
+Split monolithic \_design/todos into separate design documents

--- a/packages/core-shared/src/api/database-structures.ts
+++ b/packages/core-shared/src/api/database-structures.ts
@@ -21,7 +21,7 @@ export interface IndexDefinition {
  */
 export const DESIGN_DOCS: DesignDocument[] = [
   {
-    _id: '_design/todos',
+    _id: '_design/todos_by_active',
     views: {
       byActive: {
         map: `function (doc) {
@@ -32,6 +32,11 @@ export const DESIGN_DOCS: DesignDocument[] = [
           }
         }`,
       },
+    },
+  },
+  {
+    _id: '_design/todos_by_due_date',
+    views: {
       byDueDate: {
         map: `function (doc) {
           if (doc.due) {
@@ -39,6 +44,11 @@ export const DESIGN_DOCS: DesignDocument[] = [
           }
         }`,
       },
+    },
+  },
+  {
+    _id: '_design/todos_by_time_tracking_active',
+    views: {
       byTimeTrackingActive: {
         map: `function (doc) {
           Object.entries(doc.active).forEach((d) => {

--- a/packages/core-shared/src/api/database-structures.ts
+++ b/packages/core-shared/src/api/database-structures.ts
@@ -51,11 +51,13 @@ export const DESIGN_DOCS: DesignDocument[] = [
     views: {
       byTimeTrackingActive: {
         map: `function (doc) {
-          Object.entries(doc.active).forEach((d) => {
-            if (d[1] === null) {
-              emit(null, { id: doc._id });
-            }
-          });
+          if (doc.active) {
+            Object.entries(doc.active).forEach((d) => {
+              if (d[1] === null) {
+                emit(null, { id: doc._id });
+              }
+            });
+          }
         }`,
       },
     },

--- a/packages/web-client/src/components/todo_board.test.tsx
+++ b/packages/web-client/src/components/todo_board.test.tsx
@@ -172,7 +172,7 @@ describe('TodoBoard', () => {
       // Verify correct query parameters
       await waitFor(() => {
         expect(testDb.contextValue.safeDb.safeQuery).toHaveBeenCalledWith(
-          'todos',
+          'todos_by_due_date',
           'byDueDate',
           expect.objectContaining({
             startkey: currentStartOfWeek.toISOString(),
@@ -212,7 +212,7 @@ describe('TodoBoard', () => {
 
       await waitFor(() => {
         expect(testDb.contextValue.safeDb.safeQuery).toHaveBeenCalledWith(
-          'todos',
+          'todos_by_time_tracking_active',
           'byTimeTrackingActive',
           { key: null },
         );
@@ -255,7 +255,7 @@ describe('TodoBoard', () => {
 
       await waitFor(() => {
         expect(testDb.contextValue.safeDb.safeQuery).toHaveBeenCalledWith(
-          'todos',
+          'todos_by_active',
           'byActive',
           expect.objectContaining({
             startkey: currentStartOfWeek.toISOString(),

--- a/packages/web-client/src/hooks/use_activities_by_week.ts
+++ b/packages/web-client/src/hooks/use_activities_by_week.ts
@@ -37,12 +37,16 @@ export function useActivitiesByWeek({
     ],
     queryFn: async () => {
       console.time('fetchActivities');
-      const activities = await safeDb.safeQuery<Activity>('todos', 'byActive', {
-        descending: false,
-        endkey: endDate.toISOString(),
-        include_docs: false,
-        startkey: startDate.toISOString(),
-      });
+      const activities = await safeDb.safeQuery<Activity>(
+        'todos_by_active',
+        'byActive',
+        {
+          descending: false,
+          endkey: endDate.toISOString(),
+          include_docs: false,
+          startkey: startDate.toISOString(),
+        },
+      );
       console.timeEnd('fetchActivities');
       return activities;
     },

--- a/packages/web-client/src/hooks/use_time_tracking_active.test.ts
+++ b/packages/web-client/src/hooks/use_time_tracking_active.test.ts
@@ -120,7 +120,7 @@ describe('useTimeTrackingActive', () => {
 
     await waitFor(() =>
       expect(mockSafeDb.safeQuery).toHaveBeenCalledWith(
-        'todos',
+        'todos_by_time_tracking_active',
         'byTimeTrackingActive',
         {
           key: null,

--- a/packages/web-client/src/hooks/use_time_tracking_active.ts
+++ b/packages/web-client/src/hooks/use_time_tracking_active.ts
@@ -26,7 +26,7 @@ export function useTimeTrackingActive({
     queryFn: async () => {
       console.time('fetchTimeTrackingActive');
       const results = await safeDb.safeQuery<{ id: string }>(
-        'todos',
+        'todos_by_time_tracking_active',
         'byTimeTrackingActive',
         {
           key: null,

--- a/packages/web-client/src/hooks/use_todos_by_week.ts
+++ b/packages/web-client/src/hooks/use_todos_by_week.ts
@@ -37,12 +37,16 @@ export function useTodosByWeek({
     ],
     queryFn: async () => {
       console.time('fetchTodos');
-      const todos = await safeDb.safeQuery<Todo>('todos', 'byDueDate', {
-        descending: false,
-        endkey: endDate.toISOString(),
-        include_docs: false,
-        startkey: startDate.toISOString(),
-      });
+      const todos = await safeDb.safeQuery<Todo>(
+        'todos_by_due_date',
+        'byDueDate',
+        {
+          descending: false,
+          endkey: endDate.toISOString(),
+          include_docs: false,
+          startkey: startDate.toISOString(),
+        },
+      );
       console.timeEnd('fetchTodos');
       return todos;
     },

--- a/spec/todos/done/2025-10-05-17-36-28-split-design-docs.md
+++ b/spec/todos/done/2025-10-05-17-36-28-split-design-docs.md
@@ -1,6 +1,6 @@
 # split \_design/todos up into a design doc for each view
 
-**Status:** In Progress
+**Status:** Done
 **Created:** 2025-10-05T17:36:28Z
 **Started:** 2025-10-05T17:36:28Z
 **Agent PID:** 81503
@@ -23,12 +23,12 @@ This separation provides better modularity and follows the existing pattern (the
 
 ## Success Criteria
 
-- [ ] **Functional**: Three separate design documents exist (`_design/todos_by_active`, `_design/todos_by_due_date`, `_design/todos_by_time_tracking_active`) with correct view definitions
-- [ ] **Functional**: All existing hook queries return correct data after migration (todos grouped by week, activities by week, active time tracking entries)
-- [ ] **Functional**: Original `_design/todos` design document is removed from the definitions
-- [ ] **Build validation**: TypeScript compilation passes (`pnpm tsc:check`)
-- [ ] **Code quality**: Linting and formatting pass (`pnpm lint`, `pnpm format`)
-- [ ] **User validation**: Manual testing confirms todos display correctly in web UI, time tracking works, and no console errors appear
+- [x] **Functional**: Three separate design documents exist (`_design/todos_by_active`, `_design/todos_by_due_date`, `_design/todos_by_time_tracking_active`) with correct view definitions
+- [x] **Functional**: All existing hook queries return correct data after migration (todos grouped by week, activities by week, active time tracking entries)
+- [x] **Functional**: Original `_design/todos` design document is removed from the definitions
+- [x] **Build validation**: TypeScript compilation passes (`pnpm tsc:check`)
+- [x] **Code quality**: Linting and formatting pass (`pnpm lint`, `pnpm format`)
+- [x] **User validation**: Manual testing confirms todos display correctly in web UI, time tracking works, and no console errors appear
 
 ## Implementation Plan
 
@@ -40,10 +40,15 @@ This separation provides better modularity and follows the existing pattern (the
 - [x] Automated test: Run linting (`pnpm lint`)
 - [x] Automated test: Run formatting check (`pnpm format`)
 - [x] Automated test: Run existing unit tests (`pnpm test`)
-- [ ] User test: Start dev server and verify todos display correctly in the web UI
-- [ ] User test: Verify time tracking functionality works (start/stop tracking)
-- [ ] User test: Check browser console for errors during normal usage
+- [x] User test: Start dev server and verify todos display correctly in the web UI
+- [x] User test: Verify time tracking functionality works (start/stop tracking)
+- [x] User test: Check browser console for errors during normal usage
 
 ## Review
 
+- [x] Bug fix: Added null check for `doc.active` in `byTimeTrackingActive` view to prevent runtime errors
+
 ## Notes
+
+- Critical self-assessment revealed missing null check in `byTimeTrackingActive` view map function
+- Fixed to match pattern used in `byActive` view (both check for `doc.active` before calling `Object.entries`)

--- a/spec/todos/work/2025-10-05-17-36-28-split-design-docs/task.md
+++ b/spec/todos/work/2025-10-05-17-36-28-split-design-docs/task.md
@@ -1,0 +1,49 @@
+# split \_design/todos up into a design doc for each view
+
+**Status:** In Progress
+**Created:** 2025-10-05T17:36:28Z
+**Started:** 2025-10-05T17:36:28Z
+**Agent PID:** 81503
+
+## Description
+
+The codebase currently has a single `_design/todos` design document containing 3 views:
+
+- `byActive` - Maps time tracking activities
+- `byDueDate` - Maps todos by due date
+- `byTimeTrackingActive` - Maps currently active time tracking entries
+
+This task will split the monolithic `_design/todos` into three separate design documents, one per view:
+
+- `_design/todos_by_active`
+- `_design/todos_by_due_date`
+- `_design/todos_by_time_tracking_active`
+
+This separation provides better modularity and follows the existing pattern (the codebase already has `_design/tags` as a separate design document).
+
+## Success Criteria
+
+- [ ] **Functional**: Three separate design documents exist (`_design/todos_by_active`, `_design/todos_by_due_date`, `_design/todos_by_time_tracking_active`) with correct view definitions
+- [ ] **Functional**: All existing hook queries return correct data after migration (todos grouped by week, activities by week, active time tracking entries)
+- [ ] **Functional**: Original `_design/todos` design document is removed from the definitions
+- [ ] **Build validation**: TypeScript compilation passes (`pnpm tsc:check`)
+- [ ] **Code quality**: Linting and formatting pass (`pnpm lint`, `pnpm format`)
+- [ ] **User validation**: Manual testing confirms todos display correctly in web UI, time tracking works, and no console errors appear
+
+## Implementation Plan
+
+- [ ] Split `_design/todos` into three separate design documents in `/Users/walterra/dev/eddoapp/packages/core-shared/src/api/database-structures.ts:23-52`
+- [ ] Update query call in `/Users/walterra/dev/eddoapp/packages/web-client/src/hooks/use_activities_by_week.ts:40` to use `'todos_by_active'` design doc name
+- [ ] Update query call in `/Users/walterra/dev/eddoapp/packages/web-client/src/hooks/use_todos_by_week.ts:40` to use `'todos_by_due_date'` design doc name
+- [ ] Update query call in `/Users/walterra/dev/eddoapp/packages/web-client/src/hooks/use_time_tracking_active.ts:28` to use `'todos_by_time_tracking_active'` design doc name
+- [ ] Automated test: Run TypeScript type checking (`pnpm tsc:check`)
+- [ ] Automated test: Run linting (`pnpm lint`)
+- [ ] Automated test: Run formatting check (`pnpm format`)
+- [ ] Automated test: Run existing unit tests (`pnpm test`)
+- [ ] User test: Start dev server and verify todos display correctly in the web UI
+- [ ] User test: Verify time tracking functionality works (start/stop tracking)
+- [ ] User test: Check browser console for errors during normal usage
+
+## Review
+
+## Notes

--- a/spec/todos/work/2025-10-05-17-36-28-split-design-docs/task.md
+++ b/spec/todos/work/2025-10-05-17-36-28-split-design-docs/task.md
@@ -32,14 +32,14 @@ This separation provides better modularity and follows the existing pattern (the
 
 ## Implementation Plan
 
-- [ ] Split `_design/todos` into three separate design documents in `/Users/walterra/dev/eddoapp/packages/core-shared/src/api/database-structures.ts:23-52`
-- [ ] Update query call in `/Users/walterra/dev/eddoapp/packages/web-client/src/hooks/use_activities_by_week.ts:40` to use `'todos_by_active'` design doc name
-- [ ] Update query call in `/Users/walterra/dev/eddoapp/packages/web-client/src/hooks/use_todos_by_week.ts:40` to use `'todos_by_due_date'` design doc name
-- [ ] Update query call in `/Users/walterra/dev/eddoapp/packages/web-client/src/hooks/use_time_tracking_active.ts:28` to use `'todos_by_time_tracking_active'` design doc name
-- [ ] Automated test: Run TypeScript type checking (`pnpm tsc:check`)
-- [ ] Automated test: Run linting (`pnpm lint`)
-- [ ] Automated test: Run formatting check (`pnpm format`)
-- [ ] Automated test: Run existing unit tests (`pnpm test`)
+- [x] Split `_design/todos` into three separate design documents in `/Users/walterra/dev/eddoapp/packages/core-shared/src/api/database-structures.ts:23-52`
+- [x] Update query call in `/Users/walterra/dev/eddoapp/packages/web-client/src/hooks/use_activities_by_week.ts:40` to use `'todos_by_active'` design doc name
+- [x] Update query call in `/Users/walterra/dev/eddoapp/packages/web-client/src/hooks/use_todos_by_week.ts:40` to use `'todos_by_due_date'` design doc name
+- [x] Update query call in `/Users/walterra/dev/eddoapp/packages/web-client/src/hooks/use_time_tracking_active.ts:28` to use `'todos_by_time_tracking_active'` design doc name
+- [x] Automated test: Run TypeScript type checking (`pnpm tsc:check`)
+- [x] Automated test: Run linting (`pnpm lint`)
+- [x] Automated test: Run formatting check (`pnpm format`)
+- [x] Automated test: Run existing unit tests (`pnpm test`)
 - [ ] User test: Start dev server and verify todos display correctly in the web UI
 - [ ] User test: Verify time tracking functionality works (start/stop tracking)
 - [ ] User test: Check browser console for errors during normal usage


### PR DESCRIPTION
## Summary

- Split monolithic `_design/todos` into three separate design documents
- Each view now has its own design document: `_design/todos_by_active`, `_design/todos_by_due_date`, `_design/todos_by_time_tracking_active`
- Updated all query calls across hooks to use new design document names
- Added null check in `byTimeTrackingActive` view to prevent runtime errors

## Changes

- **core-shared**: Restructured design documents from single monolithic document to three separate documents
- **web-client**: Updated hooks to reference new design document names
- **web-client**: Updated tests to reflect new design document structure

## Test plan

- [x] TypeScript compilation passes
- [x] Linting and formatting checks pass
- [x] Existing unit tests pass
- [x] Manual testing confirms todos display correctly in web UI
- [x] Time tracking functionality works (start/stop tracking)
- [x] No console errors during normal usage