### PR TITLE
chore: simplify changesets and add github changelog

### DIFF
--- a/.changeset/claude-md-consistency.md
+++ b/.changeset/claude-md-consistency.md
@@ -9,4 +9,4 @@
 '@eddoapp/web-client': patch
 ---
 
-Enhance code quality standards with relaxed ESLint rules, update dependencies for security, fix API key logging and markdown escaping bugs, and upgrade CI to pnpm v10
+Update ESLint rules, dependencies, and CI configuration

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": "@changesets/changelog-github",
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.changeset/fix-gtd-calendar-briefing.md
+++ b/.changeset/fix-gtd-calendar-briefing.md
@@ -2,4 +2,4 @@
 '@eddo/telegram-bot': patch
 ---
 
-Fix daily briefings to include gtd:calendar tagged appointments. Updated DAILY_BRIEFING_REQUEST_MESSAGE to explicitly query for calendar events and display them with time prefixes.
+Fix daily briefings to include gtd:calendar tagged appointments

--- a/.changeset/import-formatting.md
+++ b/.changeset/import-formatting.md
@@ -8,4 +8,4 @@
 '@eddo/web-client': patch
 ---
 
-Migrate from @trivago/prettier-plugin-sort-imports to prettier-plugin-organize-imports for improved import formatting. This change standardizes import organization across all packages using TypeScript's language service API, providing consistent type import handling and automatic alphabetical sorting within logical groups.
+Migrate to prettier-plugin-organize-imports for improved import formatting

--- a/.changeset/printer-daily-briefing.md
+++ b/.changeset/printer-daily-briefing.md
@@ -7,4 +7,4 @@
 'eddo-app': minor
 ---
 
-Add thermal printer support for daily briefings on Epson TM-m30III. This feature enables automatic printing of daily briefings to a networked thermal receipt printer, with user-configurable preferences and integration into the Telegram bot workflow.
+Add thermal printer support for daily briefings on Epson TM-m30III

--- a/.changeset/show-icons-only-on-hover.md
+++ b/.changeset/show-icons-only-on-hover.md
@@ -2,4 +2,4 @@
 '@eddo/web-client': patch
 ---
 
-Implement hover-only visibility for action icons in todo cards. Edit and time tracking icons are now hidden by default and appear smoothly on hover, reducing visual clutter. Pause button remains visible when time tracking is active. Icons remain keyboard accessible via focus states.
+Show action icons only on hover to reduce visual clutter in todo cards

--- a/.changeset/tanstack-query-integration.md
+++ b/.changeset/tanstack-query-integration.md
@@ -2,14 +2,4 @@
 '@eddo/web-client': minor
 ---
 
-Add TanStack Query for data caching and state management in TodoBoard
-
-Integrate TanStack Query to replace manual data fetching and state management in the web client. This creates a hybrid architecture where TanStack Query handles caching/state management and PouchDB changes feed handles real-time updates.
-
-Key improvements:
-
-- Eliminates manual coordination code (isFetching/shouldFetch refs)
-- Replaces manual state management (isLoading, error, todos, activities)
-- Provides better TypeScript inference and built-in DevTools
-- Enables automatic query deduplication
-- Improves developer experience with standardized patterns
+Add TanStack Query for improved data caching and real-time updates

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "zod": "^3.25.67"
   },
   "devDependencies": {
+    "@changesets/changelog-github": "^0.5.2",
     "@changesets/cli": "^2.27.1",
     "@cloudant/couchbackup": "^2.11.12",
     "@commitlint/cli": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
         specifier: ^3.25.67
         version: 3.25.76
     devDependencies:
+      '@changesets/changelog-github':
+        specifier: ^0.5.2
+        version: 0.5.2
       '@changesets/cli':
         specifier: ^2.27.1
         version: 2.29.7(@types/node@24.7.2)
@@ -724,6 +727,9 @@ packages:
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
+  '@changesets/changelog-github@0.5.2':
+    resolution: {integrity: sha512-HeGeDl8HaIGj9fQHo/tv5XKQ2SNEi9+9yl1Bss1jttPqeiASRXhfi0A2wv8yFKCp07kR1gpOI5ge6+CWNm1jPw==}
+
   '@changesets/cli@2.29.7':
     resolution: {integrity: sha512-R7RqWoaksyyKXbKXBTbT4REdy22yH81mcFK6sWtqSanxUCbUi9Uf+6aqxZtDQouIqPdem2W56CdxXgsxdq7FLQ==}
     hasBin: true
@@ -736,6 +742,9 @@ packages:
 
   '@changesets/get-dependents-graph@2.1.3':
     resolution: {integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==}
+
+  '@changesets/get-github-info@0.7.0':
+    resolution: {integrity: sha512-+i67Bmhfj9V4KfDeS1+Tz3iF32btKZB2AAx+cYMqDSRFP7r3/ZdGbjCo+c6qkyViN9ygDuBjzageuPGJtKGe5A==}
 
   '@changesets/get-release-plan@4.0.13':
     resolution: {integrity: sha512-DWG1pus72FcNeXkM12tx+xtExyH/c9I1z+2aXlObH3i9YA7+WZEVaiHzHl03thpvAgWTRaH64MpfHxozfF7Dvg==}
@@ -3199,6 +3208,9 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  dataloader@1.4.0:
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
@@ -3354,6 +3366,10 @@ packages:
   dotenv@17.2.2:
     resolution: {integrity: sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==}
     engines: {node: '>=12'}
+
+  dotenv@8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
 
   double-ended-queue@2.1.0-0:
     resolution: {integrity: sha512-+BNfZ+deCo8hMNpDqDnvT+c0XpJ5cUa6mqYq89bho2Ifze4URTqRkcwR399hWoTrTkbZ/XJYDgP6rc7pRgffEQ==}
@@ -6815,6 +6831,14 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
+  '@changesets/changelog-github@0.5.2':
+    dependencies:
+      '@changesets/get-github-info': 0.7.0
+      '@changesets/types': 6.1.0
+      dotenv: 8.6.0
+    transitivePeerDependencies:
+      - encoding
+
   '@changesets/cli@2.29.7(@types/node@24.7.2)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.13
@@ -6868,6 +6892,13 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
       semver: 7.7.2
+
+  '@changesets/get-github-info@0.7.0':
+    dependencies:
+      dataloader: 1.4.0
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   '@changesets/get-release-plan@4.0.13':
     dependencies:
@@ -9259,6 +9290,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  dataloader@1.4.0: {}
+
   date-fns@4.1.0: {}
 
   debounce@2.2.0: {}
@@ -9373,6 +9406,8 @@ snapshots:
   dotenv@17.2.1: {}
 
   dotenv@17.2.2: {}
+
+  dotenv@8.6.0: {}
 
   double-ended-queue@2.1.0-0: {}
 
@@ -9982,7 +10017,7 @@ snapshots:
       strict-event-emitter-types: 2.0.0
       undici: 7.16.0
       uri-templates: 0.2.0
-      xsschema: 0.4.0-beta.5(zod-to-json-schema@3.25.0(zod@3.25.76))(zod@4.2.1)
+      xsschema: 0.4.0-beta.5(zod-to-json-schema@3.25.0(zod@4.2.1))(zod@4.2.1)
       yargs: 18.0.0
       zod: 4.2.1
       zod-to-json-schema: 3.25.0(zod@4.2.1)
@@ -12913,7 +12948,7 @@ snapshots:
       zod: 3.25.76
       zod-to-json-schema: 3.24.6(zod@3.25.76)
 
-  xsschema@0.4.0-beta.5(zod-to-json-schema@3.25.0(zod@3.25.76))(zod@4.2.1):
+  xsschema@0.4.0-beta.5(zod-to-json-schema@3.25.0(zod@4.2.1))(zod@4.2.1):
     optionalDependencies:
       zod: 4.2.1
       zod-to-json-schema: 3.25.0(zod@4.2.1)


### PR DESCRIPTION
## Changes

- Simplify all changeset descriptions to be concise, single-line entries focused on user-facing value
- Switch from default CLI changelog to @changesets/changelog-github for cleaner release notes
- Install @changesets/changelog-github package

## Benefits

- Release PRs will have less verbose dependency update listings
- Changeset descriptions follow technical writing guidelines (no filler words, direct statements)
- GitHub links for commits and contributors will be automatically included
- More professional and readable changelog format

## Related

Addresses cluttered dependency updates in PR #187