### PR TITLE
fix: add commit message to changesets release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
         uses: changesets/action@v1
         with:
           title: ${{ steps.release-version.outputs.title }}
+          commit: "chore: version packages"
           version: pnpm version-packages
           createGithubReleases: true
         env:


### PR DESCRIPTION
Adds explicit commit message configuration to the changesets action in the release workflow.

The changesets action now uses 'chore: version packages' as the commit message when versioning packages, ensuring conventional commit format compliance in automated releases.