### PR TITLE
fix: switch changeset config to CLI changelog

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "walterra/eddoapp" }],
+  "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
   "linked": [],


### PR DESCRIPTION
Changes changeset configuration from GitHub-specific changelog generator to default CLI changelog generator.

Removes dependency on @changesets/changelog-github package and reverts to simpler @changesets/cli/changelog format.

This fixes release process configuration issues related to changelog generation.