### PR TITLE
fix: lint errors in scripts and add done todos cleanup

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -139,4 +139,18 @@ export default [
       'no-undef': 'off',
     },
   },
+  {
+    files: ['scripts/**/*.js'],
+    languageOptions: {
+      sourceType: 'module',
+      globals: {
+        console: 'readonly',
+        process: 'readonly',
+        URL: 'readonly',
+        Buffer: 'readonly',
+        __dirname: 'readonly',
+        __filename: 'readonly',
+      },
+    },
+  },
 ];

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "printer": "pnpm --filter @eddo/printer-service cli",
     "format": "prettier --write ./packages",
     "lint:format": "prettier --cache --check ./packages",
-    "lint": "eslint --cache ./packages --ignore-pattern '**/dist/**'",
+    "lint": "eslint --cache ./packages ./scripts --ignore-pattern '**/dist/**'",
     "test": "pnpm test:unit",
     "test:unit": "vitest run packages/web-client/src packages/core-shared/src packages/core-server/src scripts/backup-interactive.test.ts",
     "test:integration": "node scripts/run-integration-tests.js",

--- a/scripts/__tests__/e2e/cleanup-interactive.e2e.test.ts
+++ b/scripts/__tests__/e2e/cleanup-interactive.e2e.test.ts
@@ -1,25 +1,25 @@
 import { runner } from 'clet';
 import path from 'path';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { TestDatabaseManager, generateTestDbName, createTestEnv } from './test-utils';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { TestDatabaseManager, createTestEnv, generateTestDbName } from './test-utils';
 
 const PROJECT_ROOT = path.resolve(import.meta.dirname, '../../..');
 const CLEANUP_SCRIPT = path.join(PROJECT_ROOT, 'scripts', 'cleanup-interactive.ts');
 
 describe('Cleanup Interactive E2E', () => {
   let dbManager: TestDatabaseManager;
-  
+
   beforeEach(() => {
     dbManager = new TestDatabaseManager();
   });
-  
+
   afterEach(async () => {
     await dbManager.cleanupAll();
   });
 
   it('should handle non-existent databases gracefully', async () => {
     const testEnv = createTestEnv();
-    
+
     // Try to cleanup a pattern that matches no databases
     await runner()
       .env(testEnv)
@@ -30,17 +30,17 @@ describe('Cleanup Interactive E2E', () => {
   });
 
   it.skip('should handle invalid CouchDB connection gracefully', async () => {
-    // Skip: cleanup-interactive.ts uses getCouchDbConfig (production config) instead of 
+    // Skip: cleanup-interactive.ts uses getCouchDbConfig (production config) instead of
     // getTestCouchDbConfig, so it always connects to the real CouchDB instance
     // regardless of environment variable overrides in tests.
     // This test would require modifying the actual script to use test config.
-    
+
     const testEnv = {
       ...process.env,
       COUCHDB_URL: 'http://invalid:invalid@192.0.2.1:9999',
-      COUCHDB_TEST_URL: 'http://invalid:invalid@192.0.2.1:9999'
+      COUCHDB_TEST_URL: 'http://invalid:invalid@192.0.2.1:9999',
     };
-    
+
     // Try to connect to invalid CouchDB instance (using TEST-NET-1 RFC5737)
     await runner()
       .env(testEnv)
@@ -52,7 +52,7 @@ describe('Cleanup Interactive E2E', () => {
 
   it('should correctly identify and filter test databases', async () => {
     const testEnv = createTestEnv();
-    
+
     // Create test databases with different patterns
     const testDbs = [
       generateTestDbName('eddo-test'),
@@ -60,12 +60,12 @@ describe('Cleanup Interactive E2E', () => {
       'todos-test-example',
       'production-db', // This should NOT be matched
     ];
-    
+
     // Create only the test databases (not the production one)
     for (const dbName of testDbs.slice(0, 3)) {
       await dbManager.createTestDatabase(dbName);
     }
-    
+
     // Run cleanup in dry-run mode for all test databases
     await runner()
       .env(testEnv)
@@ -80,18 +80,18 @@ describe('Cleanup Interactive E2E', () => {
 
   it('should correctly match pattern-based filtering', async () => {
     const testEnv = createTestEnv();
-    
+
     // Create databases with specific patterns
     const testDbs = [
       'test-alpha-123',
       'test-beta-456',
       'todos-test-gamma', // Should NOT match "test-*" pattern
     ];
-    
+
     for (const dbName of testDbs) {
       await dbManager.createTestDatabase(dbName);
     }
-    
+
     // Run cleanup with pattern that should only match "test-*" databases
     await runner()
       .env(testEnv)
@@ -101,23 +101,23 @@ describe('Cleanup Interactive E2E', () => {
       .stdout(/test-alpha-123/) // Should match
       .stdout(/test-beta-456/) // Should match
       .code(0);
-    
+
     // TODO: Add negative assertion for todos-test-gamma pattern matching
     // The current CLET runner doesn't support .not.stdout() properly
   });
 
   it.skip('should handle database access errors gracefully', async () => {
-    // Skip: cleanup-interactive.ts uses getCouchDbConfig (production config) instead of 
+    // Skip: cleanup-interactive.ts uses getCouchDbConfig (production config) instead of
     // getTestCouchDbConfig, so it always connects to the real CouchDB instance
     // regardless of environment variable overrides in tests.
     // This test would require modifying the actual script to use test config.
-    
+
     const testEnv = {
       ...process.env,
       COUCHDB_URL: 'http://wronguser:wrongpass@192.0.2.1:5984',
-      COUCHDB_TEST_URL: 'http://wronguser:wrongpass@192.0.2.1:5984'
+      COUCHDB_TEST_URL: 'http://wronguser:wrongpass@192.0.2.1:5984',
     };
-    
+
     // Try to access with wrong credentials (using TEST-NET-1 RFC5737)
     await runner()
       .env(testEnv)
@@ -129,19 +129,25 @@ describe('Cleanup Interactive E2E', () => {
 
   it('should respect dry-run mode and not delete databases', async () => {
     const testEnv = createTestEnv();
-    
+
     // Create a test database
     const testDbName = generateTestDbName('cleanup-dryrun');
     await dbManager.createTestDatabase(testDbName);
-    
+
     // Run cleanup in dry-run mode
     await runner()
       .env(testEnv)
       .cwd(PROJECT_ROOT)
-      .spawn('tsx', [CLEANUP_SCRIPT, '--pattern', `${testDbName.split('-')[0]}-*`, '--dry-run', '--force'])
+      .spawn('tsx', [
+        CLEANUP_SCRIPT,
+        '--pattern',
+        `${testDbName.split('-')[0]}-*`,
+        '--dry-run',
+        '--force',
+      ])
       .stdout(/Dry-run complete. No databases were deleted/)
       .code(0);
-    
+
     // Verify database still exists
     const stillExists = await dbManager.databaseExists(testDbName);
     expect(stillExists).toBe(true);

--- a/scripts/__tests__/e2e/restore-interactive.e2e.test.ts
+++ b/scripts/__tests__/e2e/restore-interactive.e2e.test.ts
@@ -1,9 +1,14 @@
 import { runner } from 'clet';
 import fs from 'fs';
-import path from 'path';
 import os from 'os';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { TestDatabaseManager, generateTestDbName, createTestEnv, SAMPLE_TODO_DOCS } from './test-utils';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  createTestEnv,
+  generateTestDbName,
+  SAMPLE_TODO_DOCS,
+  TestDatabaseManager,
+} from './test-utils';
 
 const PROJECT_ROOT = path.resolve(import.meta.dirname, '../../..');
 const BACKUP_SCRIPT = path.join(PROJECT_ROOT, 'scripts', 'backup-interactive.ts');
@@ -13,14 +18,14 @@ describe('Restore Interactive E2E', () => {
   let testDir: string;
   let backupDir: string;
   let dbManager: TestDatabaseManager;
-  
+
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'restore-test-'));
     backupDir = path.join(testDir, 'backups');
     fs.mkdirSync(backupDir, { recursive: true });
     dbManager = new TestDatabaseManager();
   });
-  
+
   afterEach(async () => {
     await dbManager.cleanupAll();
     if (fs.existsSync(testDir)) {
@@ -44,12 +49,21 @@ describe('Restore Interactive E2E', () => {
     await runner()
       .env(testEnv)
       .cwd(PROJECT_ROOT)
-      .spawn('tsx', [BACKUP_SCRIPT, '--no-interactive', '--database', sourceDbName, '--backup-dir', backupDir])
+      .spawn('tsx', [
+        BACKUP_SCRIPT,
+        '--no-interactive',
+        '--database',
+        sourceDbName,
+        '--backup-dir',
+        backupDir,
+      ])
       .stdout(/Backup Summary:/)
       .code(0);
 
     // Step 3: Find the backup file
-    const backupFiles = fs.readdirSync(backupDir).filter(f => f.startsWith(sourceDbName) && f.endsWith('.json'));
+    const backupFiles = fs
+      .readdirSync(backupDir)
+      .filter((f) => f.startsWith(sourceDbName) && f.endsWith('.json'));
     expect(backupFiles.length).toBe(1);
     const backupFile = path.join(backupDir, backupFiles[0]);
 
@@ -57,7 +71,15 @@ describe('Restore Interactive E2E', () => {
     await runner()
       .env(testEnv)
       .cwd(PROJECT_ROOT)
-      .spawn('tsx', [RESTORE_SCRIPT, '--no-interactive', '--database', targetDbName, '--backup-file', backupFile, '--force-overwrite'])
+      .spawn('tsx', [
+        RESTORE_SCRIPT,
+        '--no-interactive',
+        '--database',
+        targetDbName,
+        '--backup-file',
+        backupFile,
+        '--force-overwrite',
+      ])
       .stdout(/Restore Summary:/)
       .stdout(new RegExp(targetDbName))
       .code(0);
@@ -78,7 +100,16 @@ describe('Restore Interactive E2E', () => {
     await runner()
       .env(testEnv)
       .cwd(PROJECT_ROOT)
-      .spawn('tsx', [RESTORE_SCRIPT, '--dry-run', '--no-interactive', '--database', targetDbName, '--backup-file', mockBackupFile, '--force-overwrite'])
+      .spawn('tsx', [
+        RESTORE_SCRIPT,
+        '--dry-run',
+        '--no-interactive',
+        '--database',
+        targetDbName,
+        '--backup-file',
+        mockBackupFile,
+        '--force-overwrite',
+      ])
       .stdout(/Dry run mode/)
       .stdout(new RegExp(targetDbName))
       .code(0);
@@ -97,11 +128,18 @@ describe('Restore Interactive E2E', () => {
     const targetDbName = generateTestDbName('file-check-test');
     const nonExistentFile = path.join(testDir, 'nonexistent.json');
     const testEnv = createTestEnv();
-    
+
     await runner()
       .env(testEnv)
       .cwd(PROJECT_ROOT)
-      .spawn('tsx', [RESTORE_SCRIPT, '--no-interactive', '--database', targetDbName, '--backup-file', nonExistentFile])
+      .spawn('tsx', [
+        RESTORE_SCRIPT,
+        '--no-interactive',
+        '--database',
+        targetDbName,
+        '--backup-file',
+        nonExistentFile,
+      ])
       .stderr(/does not exist|not found/)
       .code(1);
   }, 30000);
@@ -121,18 +159,39 @@ describe('Restore Interactive E2E', () => {
     await runner()
       .env(testEnv)
       .cwd(PROJECT_ROOT)
-      .spawn('tsx', [BACKUP_SCRIPT, '--no-interactive', '--database', sourceDbName, '--backup-dir', backupDir])
+      .spawn('tsx', [
+        BACKUP_SCRIPT,
+        '--no-interactive',
+        '--database',
+        sourceDbName,
+        '--backup-dir',
+        backupDir,
+      ])
       .stdout(/Backup Summary:/)
       .code(0);
 
-    const backupFiles = fs.readdirSync(backupDir).filter(f => f.startsWith(sourceDbName) && f.endsWith('.json'));
+    const backupFiles = fs
+      .readdirSync(backupDir)
+      .filter((f) => f.startsWith(sourceDbName) && f.endsWith('.json'));
     const backupFile = path.join(backupDir, backupFiles[0]);
 
     // Test restore with custom parameters
     await runner()
       .env(testEnv)
       .cwd(PROJECT_ROOT)
-      .spawn('tsx', [RESTORE_SCRIPT, '--no-interactive', '--database', targetDbName, '--backup-file', backupFile, '--parallelism', '3', '--timeout', '60000', '--force-overwrite'])
+      .spawn('tsx', [
+        RESTORE_SCRIPT,
+        '--no-interactive',
+        '--database',
+        targetDbName,
+        '--backup-file',
+        backupFile,
+        '--parallelism',
+        '3',
+        '--timeout',
+        '60000',
+        '--force-overwrite',
+      ])
       .stdout(/Restore Configuration:/)
       .stdout(new RegExp(targetDbName))
       .stdout(/Parallelism: 3/)
@@ -153,7 +212,14 @@ describe('Restore Interactive E2E', () => {
     await runner()
       .env(testEnv)
       .cwd(PROJECT_ROOT)
-      .spawn('tsx', [RESTORE_SCRIPT, '--no-interactive', '--database', targetDbName, '--backup-file', mockBackupFile])
+      .spawn('tsx', [
+        RESTORE_SCRIPT,
+        '--no-interactive',
+        '--database',
+        targetDbName,
+        '--backup-file',
+        mockBackupFile,
+      ])
       .stdout(/Restore cancelled - force overwrite not confirmed/)
       .code(0);
   }, 30000);
@@ -176,33 +242,56 @@ describe('Restore Interactive E2E', () => {
     await runner()
       .env(testEnv)
       .cwd(PROJECT_ROOT)
-      .spawn('tsx', [BACKUP_SCRIPT, '--no-interactive', '--database', sourceDbName, '--backup-dir', customBackupDir])
+      .spawn('tsx', [
+        BACKUP_SCRIPT,
+        '--no-interactive',
+        '--database',
+        sourceDbName,
+        '--backup-dir',
+        customBackupDir,
+      ])
       .stdout(/Backup Summary:/)
       .code(0);
 
-    const backupFiles = fs.readdirSync(customBackupDir).filter(f => f.startsWith(sourceDbName) && f.endsWith('.json'));
+    const backupFiles = fs
+      .readdirSync(customBackupDir)
+      .filter((f) => f.startsWith(sourceDbName) && f.endsWith('.json'));
     const backupFile = path.join(customBackupDir, backupFiles[0]);
 
     // Test restore from custom directory
     await runner()
       .env(testEnv)
       .cwd(PROJECT_ROOT)
-      .spawn('tsx', [RESTORE_SCRIPT, '--no-interactive', '--database', targetDbName, '--backup-file', backupFile, '--backup-dir', customBackupDir, '--force-overwrite'])
+      .spawn('tsx', [
+        RESTORE_SCRIPT,
+        '--no-interactive',
+        '--database',
+        targetDbName,
+        '--backup-file',
+        backupFile,
+        '--backup-dir',
+        customBackupDir,
+        '--force-overwrite',
+      ])
       .stdout(/Restore Summary:/)
       .code(0);
   }, 45000);
 
-  it.skipIf(process.env.CI)('should handle user cancellation in interactive mode', async () => {
-    const testEnv = createTestEnv();
+  it.skipIf(process.env.CI)(
+    'should handle user cancellation in interactive mode',
+    async () => {
+      const testEnv = createTestEnv();
 
-    await runner()
-      .env(testEnv)
-      .cwd(PROJECT_ROOT)
-      .spawn('tsx', [RESTORE_SCRIPT])
-      .stdin(/Select target database for restore:/, '\x03') // Ctrl+C to cancel
-      .stdout(/Restore cancelled/i)
-      .code(0); // prompts library exits with 0 when cancelled
-  }, 30000);
+      await runner()
+        .env(testEnv)
+        .cwd(PROJECT_ROOT)
+        .spawn('tsx', [RESTORE_SCRIPT])
+        .stdin(/Select target database for restore:/, '\x03') // Ctrl+C to cancel
+        .stdout(/Restore cancelled/i)
+        .code(0); // prompts library exits with 0 when cancelled
+    },
+    30000,
+  );
 
   it('should validate parallelism parameter range', async () => {
     const sourceDbName = generateTestDbName('parallelism-source');
@@ -219,17 +308,36 @@ describe('Restore Interactive E2E', () => {
     await runner()
       .env(testEnv)
       .cwd(PROJECT_ROOT)
-      .spawn('tsx', [BACKUP_SCRIPT, '--no-interactive', '--database', sourceDbName, '--backup-dir', backupDir])
+      .spawn('tsx', [
+        BACKUP_SCRIPT,
+        '--no-interactive',
+        '--database',
+        sourceDbName,
+        '--backup-dir',
+        backupDir,
+      ])
       .stdout(/Backup Summary:/)
       .code(0);
 
-    const backupFiles = fs.readdirSync(backupDir).filter(f => f.startsWith(sourceDbName) && f.endsWith('.json'));
+    const backupFiles = fs
+      .readdirSync(backupDir)
+      .filter((f) => f.startsWith(sourceDbName) && f.endsWith('.json'));
     const backupFile = path.join(backupDir, backupFiles[0]);
 
     await runner()
       .env(testEnv)
       .cwd(PROJECT_ROOT)
-      .spawn('tsx', [RESTORE_SCRIPT, '--no-interactive', '--database', targetDbName, '--backup-file', backupFile, '--parallelism', '8', '--force-overwrite'])
+      .spawn('tsx', [
+        RESTORE_SCRIPT,
+        '--no-interactive',
+        '--database',
+        targetDbName,
+        '--backup-file',
+        backupFile,
+        '--parallelism',
+        '8',
+        '--force-overwrite',
+      ])
       .stdout(/Parallelism: 8/)
       .stdout(/Restore Summary:/)
       .code(0);
@@ -262,7 +370,15 @@ describe('Restore Interactive E2E', () => {
     await runner()
       .env(testEnv)
       .cwd(PROJECT_ROOT)
-      .spawn('tsx', [RESTORE_SCRIPT, '--no-interactive', '--database', targetDbName, '--backup-file', invalidBackupFile, '--force-overwrite'])
+      .spawn('tsx', [
+        RESTORE_SCRIPT,
+        '--no-interactive',
+        '--database',
+        targetDbName,
+        '--backup-file',
+        invalidBackupFile,
+        '--force-overwrite',
+      ])
       .stdout(/Restore Summary:/)
       .code(0);
 
@@ -275,14 +391,14 @@ describe('Restore Interactive E2E - File Discovery', () => {
   let testDir: string;
   let backupDir: string;
   let dbManager: TestDatabaseManager;
-  
+
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'restore-discovery-test-'));
     backupDir = path.join(testDir, 'backups');
     fs.mkdirSync(backupDir, { recursive: true });
     dbManager = new TestDatabaseManager();
   });
-  
+
   afterEach(async () => {
     await dbManager.cleanupAll();
     if (fs.existsSync(testDir)) {
@@ -300,21 +416,28 @@ describe('Restore Interactive E2E - File Discovery', () => {
 
     // Create multiple source databases and their backups
     const databases = [`${sourceDbName}-dev`, `${sourceDbName}-prod`, `${sourceDbName}-test`];
-    
+
     for (const dbName of databases) {
       await dbManager.createTestDatabase(dbName);
       await dbManager.addSampleData(dbName, [SAMPLE_TODO_DOCS[0]]);
-      
+
       await runner()
         .env(testEnv)
         .cwd(PROJECT_ROOT)
-        .spawn('tsx', [BACKUP_SCRIPT, '--no-interactive', '--database', dbName, '--backup-dir', backupDir])
+        .spawn('tsx', [
+          BACKUP_SCRIPT,
+          '--no-interactive',
+          '--database',
+          dbName,
+          '--backup-dir',
+          backupDir,
+        ])
         .stdout(/Backup Summary:/)
         .code(0);
     }
 
     // Verify multiple backup files were created
-    const backupFiles = fs.readdirSync(backupDir).filter(f => f.endsWith('.json'));
+    const backupFiles = fs.readdirSync(backupDir).filter((f) => f.endsWith('.json'));
     expect(backupFiles.length).toBe(3);
 
     // Test restore using one of the backup files
@@ -322,47 +445,70 @@ describe('Restore Interactive E2E - File Discovery', () => {
     await runner()
       .env(testEnv)
       .cwd(PROJECT_ROOT)
-      .spawn('tsx', [RESTORE_SCRIPT, '--no-interactive', '--database', targetDbName, '--backup-file', selectedBackupFile, '--force-overwrite'])
+      .spawn('tsx', [
+        RESTORE_SCRIPT,
+        '--no-interactive',
+        '--database',
+        targetDbName,
+        '--backup-file',
+        selectedBackupFile,
+        '--force-overwrite',
+      ])
       .stdout(/Restore Summary:/)
       .code(0);
   }, 60000);
 
-  it.skipIf(process.env.CI)('should discover backup files in directory', async () => {
-    const sourceDbName = generateTestDbName('interactive-discovery');
-    const testEnv = createTestEnv();
+  it.skipIf(process.env.CI)(
+    'should discover backup files in directory',
+    async () => {
+      const sourceDbName = generateTestDbName('interactive-discovery');
+      const testEnv = createTestEnv();
 
-    // Create a real backup file
-    await dbManager.createTestDatabase(sourceDbName);
-    await dbManager.addSampleData(sourceDbName, [SAMPLE_TODO_DOCS[0]]);
+      // Create a real backup file
+      await dbManager.createTestDatabase(sourceDbName);
+      await dbManager.addSampleData(sourceDbName, [SAMPLE_TODO_DOCS[0]]);
 
-    await runner()
-      .env(testEnv)
-      .cwd(PROJECT_ROOT)
-      .spawn('tsx', [BACKUP_SCRIPT, '--no-interactive', '--database', sourceDbName, '--backup-dir', backupDir])
-      .stdout(/Backup Summary:/)
-      .code(0);
+      await runner()
+        .env(testEnv)
+        .cwd(PROJECT_ROOT)
+        .spawn('tsx', [
+          BACKUP_SCRIPT,
+          '--no-interactive',
+          '--database',
+          sourceDbName,
+          '--backup-dir',
+          backupDir,
+        ])
+        .stdout(/Backup Summary:/)
+        .code(0);
 
-    // Start the command and cancel immediately to test file discovery
-    await runner()
-      .env(testEnv)
-      .cwd(PROJECT_ROOT)
-      .spawn('tsx', [RESTORE_SCRIPT, '--backup-dir', backupDir])
-      .stdin(/Select target database for restore:/, '\x03') // Cancel after discovery
-      .stdout(/Restore cancelled/i)
-      .code(0);
-  }, 45000);
+      // Start the command and cancel immediately to test file discovery
+      await runner()
+        .env(testEnv)
+        .cwd(PROJECT_ROOT)
+        .spawn('tsx', [RESTORE_SCRIPT, '--backup-dir', backupDir])
+        .stdin(/Select target database for restore:/, '\x03') // Cancel after discovery
+        .stdout(/Restore cancelled/i)
+        .code(0);
+    },
+    45000,
+  );
 
-  it.skipIf(process.env.CI)('should handle empty backup directory', async () => {
-    const emptyBackupDir = path.join(testDir, 'empty');
-    fs.mkdirSync(emptyBackupDir, { recursive: true });
-    const testEnv = createTestEnv();
+  it.skipIf(process.env.CI)(
+    'should handle empty backup directory',
+    async () => {
+      const emptyBackupDir = path.join(testDir, 'empty');
+      fs.mkdirSync(emptyBackupDir, { recursive: true });
+      const testEnv = createTestEnv();
 
-    await runner()
-      .env(testEnv)
-      .cwd(PROJECT_ROOT)
-      .spawn('tsx', [RESTORE_SCRIPT, '--backup-dir', emptyBackupDir])
-      .stdin(/Select target database for restore:/, '\x03') // Cancel at first prompt
-      .stdout(/Restore cancelled/i)
-      .code(0);
-  }, 30000);
+      await runner()
+        .env(testEnv)
+        .cwd(PROJECT_ROOT)
+        .spawn('tsx', [RESTORE_SCRIPT, '--backup-dir', emptyBackupDir])
+        .stdin(/Select target database for restore:/, '\x03') // Cancel at first prompt
+        .stdout(/Restore cancelled/i)
+        .code(0);
+    },
+    30000,
+  );
 });

--- a/scripts/__tests__/e2e/test-utils.ts
+++ b/scripts/__tests__/e2e/test-utils.ts
@@ -2,7 +2,7 @@
  * E2E Test Utilities
  * Provides helper functions for setting up and cleaning up CouchDB databases in e2e tests
  */
-import { validateEnv, getTestCouchDbConfig, cleanupDatabasesByPattern } from '@eddo/core-server';
+import { cleanupDatabasesByPattern, getTestCouchDbConfig, validateEnv } from '@eddo/core-server';
 import nano from 'nano';
 
 /**
@@ -20,7 +20,7 @@ export function generateTestDbName(prefix: string): string {
 export function createTestEnv(customDbName?: string) {
   const env = validateEnv(process.env);
   const testCouchConfig = getTestCouchDbConfig(env);
-  
+
   return {
     ...process.env,
     COUCHDB_URL: testCouchConfig.url,
@@ -50,12 +50,7 @@ export class TestDatabaseManager {
       this.createdDatabases.add(dbName);
       console.log(`📁 Created test database: ${dbName}`);
     } catch (error: unknown) {
-      if (
-        error &&
-        typeof error === 'object' &&
-        'statusCode' in error &&
-        error.statusCode === 412
-      ) {
+      if (error && typeof error === 'object' && 'statusCode' in error && error.statusCode === 412) {
         // Database already exists
         this.createdDatabases.add(dbName);
         console.log(`📁 Test database already exists: ${dbName}`);
@@ -82,12 +77,7 @@ export class TestDatabaseManager {
       this.createdDatabases.delete(dbName);
       console.log(`🗑️  Deleted test database: ${dbName}`);
     } catch (error: unknown) {
-      if (
-        error &&
-        typeof error === 'object' &&
-        'statusCode' in error &&
-        error.statusCode === 404
-      ) {
+      if (error && typeof error === 'object' && 'statusCode' in error && error.statusCode === 404) {
         // Database doesn't exist
         console.log(`ℹ️  Test database doesn't exist: ${dbName}`);
       } else {
@@ -111,11 +101,13 @@ export class TestDatabaseManager {
    * Clean up all test databases matching pattern, including untracked ones
    * This is useful for cleaning up databases created by external scripts
    */
-  async cleanupAllTestDatabases(options: { dryRun?: boolean; verbose?: boolean } = {}): Promise<void> {
+  async cleanupAllTestDatabases(
+    options: { dryRun?: boolean; verbose?: boolean } = {},
+  ): Promise<void> {
     try {
       // Clean up tracked databases first
       await this.cleanupAll();
-      
+
       // Clean up any remaining test databases using pattern matching
       const testDatabasePattern = /^test-/;
       const result = await cleanupDatabasesByPattern(testDatabasePattern, {
@@ -123,14 +115,14 @@ export class TestDatabaseManager {
         verbose: options.verbose || false,
         force: true, // Force cleanup for test databases
       });
-      
+
       if (options.verbose) {
         console.log(`🧹 Pattern-based cleanup completed:`);
         console.log(`  Cleaned: ${result.summary.cleaned}`);
         console.log(`  Skipped: ${result.summary.skipped}`);
         console.log(`  Errors: ${result.summary.errors}`);
       }
-      
+
       if (result.errors.length > 0) {
         console.warn(`⚠️  Some databases could not be cleaned up:`, result.errors);
       }
@@ -143,7 +135,11 @@ export class TestDatabaseManager {
   /**
    * Wait for database to be fully created/deleted (useful for timing-sensitive tests)
    */
-  async waitForDatabase(dbName: string, shouldExist: boolean, maxRetries: number = 10): Promise<void> {
+  async waitForDatabase(
+    dbName: string,
+    shouldExist: boolean,
+    maxRetries: number = 10,
+  ): Promise<void> {
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
         await this.couch.db.get(dbName);
@@ -151,7 +147,7 @@ export class TestDatabaseManager {
           return; // Database exists as expected
         }
         // Database exists but shouldn't - wait and retry
-        await new Promise(resolve => setTimeout(resolve, 100 * attempt));
+        await new Promise((resolve) => setTimeout(resolve, 100 * attempt));
       } catch (error: unknown) {
         if (
           error &&
@@ -163,19 +159,21 @@ export class TestDatabaseManager {
             return; // Database doesn't exist as expected
           }
           // Database doesn't exist but should - wait and retry
-          await new Promise(resolve => setTimeout(resolve, 100 * attempt));
+          await new Promise((resolve) => setTimeout(resolve, 100 * attempt));
         } else {
           throw error;
         }
       }
     }
-    throw new Error(`Database ${dbName} ${shouldExist ? 'creation' : 'deletion'} verification timed out`);
+    throw new Error(
+      `Database ${dbName} ${shouldExist ? 'creation' : 'deletion'} verification timed out`,
+    );
   }
 
   /**
    * Add sample data to a test database
    */
-  async addSampleData(dbName: string, docs: any[]): Promise<void> {
+  async addSampleData(dbName: string, docs: Record<string, unknown>[]): Promise<void> {
     const db = this.couch.db.use(dbName);
     for (const doc of docs) {
       try {
@@ -195,12 +193,7 @@ export class TestDatabaseManager {
       await this.couch.db.get(dbName);
       return true;
     } catch (error: unknown) {
-      if (
-        error &&
-        typeof error === 'object' &&
-        'statusCode' in error &&
-        error.statusCode === 404
-      ) {
+      if (error && typeof error === 'object' && 'statusCode' in error && error.statusCode === 404) {
         return false;
       }
       throw error;
@@ -213,7 +206,7 @@ export class TestDatabaseManager {
   async getTestDatabases(): Promise<string[]> {
     try {
       const allDbs = await this.couch.db.list();
-      return allDbs.filter(db => db.startsWith('test-'));
+      return allDbs.filter((db) => db.startsWith('test-'));
     } catch (error) {
       console.warn('⚠️  Failed to list databases:', error);
       return [];

--- a/scripts/__tests__/replicate-preservation.test.ts
+++ b/scripts/__tests__/replicate-preservation.test.ts
@@ -3,8 +3,8 @@
  * These tests ensure that replication is additive, not destructive
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 import nano from 'nano';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { checkDatabaseExists } from '../backup-utils.js';
 
 // Mock dependencies
@@ -36,11 +36,11 @@ describe('replication data preservation', () => {
     // - Source has 10 documents
     // - Target has 5 existing documents
     // - After replication, target should have more documents (not replaced)
-    
+
     // Mock database existence checks
     mockCheckDatabaseExists
-      .mockResolvedValueOnce({ exists: true, docCount: 10 })  // source: 10 docs
-      .mockResolvedValueOnce({ exists: true, docCount: 5 })   // target: 5 docs before
+      .mockResolvedValueOnce({ exists: true, docCount: 10 }) // source: 10 docs
+      .mockResolvedValueOnce({ exists: true, docCount: 5 }) // target: 5 docs before
       .mockResolvedValueOnce({ exists: true, docCount: 12 }); // target: 12 docs after (5 + 7 new, some might be updates)
 
     // Mock nano database operations
@@ -48,16 +48,18 @@ describe('replication data preservation', () => {
       create: vi.fn().mockResolvedValue({}),
       replicate: vi.fn().mockResolvedValue({
         ok: true,
-        history: [{
-          docs_written: 7,     // 7 documents were written (some new, some updates)
-          docs_read: 10,       // 10 documents were read from source
-          missing_checked: 7,  // 7 documents were missing in target
-          doc_write_failures: 0,
-        }],
+        history: [
+          {
+            docs_written: 7, // 7 documents were written (some new, some updates)
+            docs_read: 10, // 10 documents were read from source
+            missing_checked: 7, // 7 documents were missing in target
+            doc_write_failures: 0,
+          },
+        ],
       }),
     };
 
-    mockNano.mockReturnValue({ db: mockDb } as any);
+    mockNano.mockReturnValue({ db: mockDb } as unknown as ReturnType<typeof nano>);
 
     // Test the replication behavior
     const couch = nano('http://admin:password@localhost:5984');
@@ -87,26 +89,28 @@ describe('replication data preservation', () => {
   it('should handle document conflicts by preserving both versions', async () => {
     // Simulate a scenario where both source and target have the same document ID
     // CouchDB replication should handle this via conflict resolution, not deletion
-    
+
     mockCheckDatabaseExists
-      .mockResolvedValueOnce({ exists: true, docCount: 3 })   // source: 3 docs
-      .mockResolvedValueOnce({ exists: true, docCount: 3 })   // target: 3 docs (some overlapping)
-      .mockResolvedValueOnce({ exists: true, docCount: 4 });  // target: 4 docs after (conflicts handled)
+      .mockResolvedValueOnce({ exists: true, docCount: 3 }) // source: 3 docs
+      .mockResolvedValueOnce({ exists: true, docCount: 3 }) // target: 3 docs (some overlapping)
+      .mockResolvedValueOnce({ exists: true, docCount: 4 }); // target: 4 docs after (conflicts handled)
 
     const mockDb = {
       create: vi.fn().mockResolvedValue({}),
       replicate: vi.fn().mockResolvedValue({
         ok: true,
-        history: [{
-          docs_written: 1,     // 1 document was written (conflict resolution)
-          docs_read: 3,        // 3 documents were read from source
-          missing_checked: 1,  // 1 document was missing in target
-          doc_write_failures: 0,
-        }],
+        history: [
+          {
+            docs_written: 1, // 1 document was written (conflict resolution)
+            docs_read: 3, // 3 documents were read from source
+            missing_checked: 1, // 1 document was missing in target
+            doc_write_failures: 0,
+          },
+        ],
       }),
     };
 
-    mockNano.mockReturnValue({ db: mockDb } as any);
+    mockNano.mockReturnValue({ db: mockDb } as unknown as ReturnType<typeof nano>);
 
     const couch = nano('http://admin:password@localhost:5984');
     const replicationResult = await couch.db.replicate('source-db', 'target-db', {
@@ -116,7 +120,7 @@ describe('replication data preservation', () => {
 
     expect(replicationResult.ok).toBe(true);
     expect(replicationResult.history[0].doc_write_failures).toBe(0);
-    
+
     // Even with conflicts, replication should succeed without data loss
     expect(mockDb.replicate).toHaveBeenCalledWith('source-db', 'target-db', {
       create_target: false,
@@ -134,7 +138,7 @@ describe('replication data preservation', () => {
       }),
     };
 
-    mockNano.mockReturnValue({ db: mockDb } as any);
+    mockNano.mockReturnValue({ db: mockDb } as unknown as ReturnType<typeof nano>);
 
     const couch = nano('http://admin:password@localhost:5984');
     await couch.db.replicate('source-db', 'target-db', {
@@ -145,12 +149,12 @@ describe('replication data preservation', () => {
     // Verify that no destructive options are used
     const replicationCall = mockDb.replicate.mock.calls[0];
     const options = replicationCall[2];
-    
+
     // These options should NOT be present (they would be destructive)
     expect(options).not.toHaveProperty('doc_ids'); // Would limit to specific docs
-    expect(options).not.toHaveProperty('filter');  // Could filter out existing docs
-    expect(options.create_target).toBe(false);     // We handle target creation ourselves
-    
+    expect(options).not.toHaveProperty('filter'); // Could filter out existing docs
+    expect(options.create_target).toBe(false); // We handle target creation ourselves
+
     // These options should be present (they are safe)
     expect(options).toHaveProperty('continuous');
     expect(options.continuous).toBe(false);
@@ -159,24 +163,26 @@ describe('replication data preservation', () => {
   it('should handle empty source database without affecting target', async () => {
     // Test edge case: empty source database should not affect target
     mockCheckDatabaseExists
-      .mockResolvedValueOnce({ exists: true, docCount: 0 })   // source: empty
-      .mockResolvedValueOnce({ exists: true, docCount: 5 })   // target: 5 docs
-      .mockResolvedValueOnce({ exists: true, docCount: 5 });  // target: still 5 docs
+      .mockResolvedValueOnce({ exists: true, docCount: 0 }) // source: empty
+      .mockResolvedValueOnce({ exists: true, docCount: 5 }) // target: 5 docs
+      .mockResolvedValueOnce({ exists: true, docCount: 5 }); // target: still 5 docs
 
     const mockDb = {
       create: vi.fn().mockResolvedValue({}),
       replicate: vi.fn().mockResolvedValue({
         ok: true,
-        history: [{
-          docs_written: 0,     // No documents to write
-          docs_read: 0,        // No documents to read
-          missing_checked: 0,  // No documents were missing
-          doc_write_failures: 0,
-        }],
+        history: [
+          {
+            docs_written: 0, // No documents to write
+            docs_read: 0, // No documents to read
+            missing_checked: 0, // No documents were missing
+            doc_write_failures: 0,
+          },
+        ],
       }),
     };
 
-    mockNano.mockReturnValue({ db: mockDb } as any);
+    mockNano.mockReturnValue({ db: mockDb } as unknown as ReturnType<typeof nano>);
 
     const couch = nano('http://admin:password@localhost:5984');
     const replicationResult = await couch.db.replicate('empty-db', 'target-db', {
@@ -187,7 +193,7 @@ describe('replication data preservation', () => {
     expect(replicationResult.ok).toBe(true);
     expect(replicationResult.history[0].docs_written).toBe(0);
     expect(replicationResult.history[0].doc_write_failures).toBe(0);
-    
+
     // Target should be unchanged
     expect(mockDb.replicate).toHaveBeenCalledWith('empty-db', 'target-db', {
       create_target: false,

--- a/scripts/__tests__/replicate.test.ts
+++ b/scripts/__tests__/replicate.test.ts
@@ -2,10 +2,10 @@
  * Tests for CouchDB replication functionality
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 import nano from 'nano';
-import { replicate } from '../replicate.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { checkDatabaseExists } from '../backup-utils.js';
+import { replicate } from '../replicate.js';
 
 // Mock dependencies
 vi.mock('nano');
@@ -40,7 +40,7 @@ const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 describe('replicate', () => {
   const mockNano = vi.mocked(nano);
   const mockCheckDatabaseExists = vi.mocked(checkDatabaseExists);
-  
+
   beforeEach(() => {
     vi.clearAllMocks();
     process.argv = [...originalArgv];
@@ -55,11 +55,11 @@ describe('replicate', () => {
   it('should replicate from source to target database', async () => {
     // Mock command line arguments
     process.argv = ['node', 'replicate.ts', 'source-db', 'target-db'];
-    
+
     // Mock database existence checks
     mockCheckDatabaseExists
       .mockResolvedValueOnce({ exists: true, docCount: 10 }) // source
-      .mockResolvedValueOnce({ exists: true, docCount: 5 })  // target
+      .mockResolvedValueOnce({ exists: true, docCount: 5 }) // target
       .mockResolvedValueOnce({ exists: true, docCount: 12 }); // final target check
 
     // Mock nano and replication
@@ -67,16 +67,18 @@ describe('replicate', () => {
       create: vi.fn().mockResolvedValue({}),
       replicate: vi.fn().mockResolvedValue({
         ok: true,
-        history: [{
-          docs_written: 2,
-          docs_read: 2,
-          missing_checked: 0,
-          doc_write_failures: 0,
-        }],
+        history: [
+          {
+            docs_written: 2,
+            docs_read: 2,
+            missing_checked: 0,
+            doc_write_failures: 0,
+          },
+        ],
       }),
     };
 
-    mockNano.mockReturnValue({ db: mockDb } as any);
+    mockNano.mockReturnValue({ db: mockDb } as unknown as ReturnType<typeof nano>);
 
     // Mock process.exit to prevent actual exit
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
@@ -85,7 +87,7 @@ describe('replicate', () => {
 
     try {
       await replicate();
-    } catch (error) {
+    } catch (_error) {
       // Expected if process.exit is called
     }
 
@@ -100,11 +102,11 @@ describe('replicate', () => {
   it('should create target database if it does not exist', async () => {
     // Mock command line arguments
     process.argv = ['node', 'replicate.ts', 'source-db', 'new-target-db'];
-    
+
     // Mock database existence checks
     mockCheckDatabaseExists
-      .mockResolvedValueOnce({ exists: true, docCount: 10 })  // source exists
-      .mockResolvedValueOnce({ exists: false, docCount: 0 })  // target does not exist
+      .mockResolvedValueOnce({ exists: true, docCount: 10 }) // source exists
+      .mockResolvedValueOnce({ exists: false, docCount: 0 }) // target does not exist
       .mockResolvedValueOnce({ exists: true, docCount: 10 }); // final target check
 
     // Mock nano and replication
@@ -112,16 +114,18 @@ describe('replicate', () => {
       create: vi.fn().mockResolvedValue({}),
       replicate: vi.fn().mockResolvedValue({
         ok: true,
-        history: [{
-          docs_written: 10,
-          docs_read: 10,
-          missing_checked: 0,
-          doc_write_failures: 0,
-        }],
+        history: [
+          {
+            docs_written: 10,
+            docs_read: 10,
+            missing_checked: 0,
+            doc_write_failures: 0,
+          },
+        ],
       }),
     };
 
-    mockNano.mockReturnValue({ db: mockDb } as any);
+    mockNano.mockReturnValue({ db: mockDb } as unknown as ReturnType<typeof nano>);
 
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('Process exit called');
@@ -129,7 +133,7 @@ describe('replicate', () => {
 
     try {
       await replicate();
-    } catch (error) {
+    } catch (_error) {
       // Expected if process.exit is called
     }
 
@@ -144,7 +148,7 @@ describe('replicate', () => {
   it('should handle continuous replication', async () => {
     // Mock command line arguments
     process.argv = ['node', 'replicate.ts', 'source-db', 'target-db', '--continuous'];
-    
+
     // Mock database existence checks
     mockCheckDatabaseExists
       .mockResolvedValueOnce({ exists: true, docCount: 10 })
@@ -156,16 +160,18 @@ describe('replicate', () => {
       replicate: vi.fn().mockResolvedValue({
         ok: true,
         _id: 'replication-id-123',
-        history: [{
-          docs_written: 2,
-          docs_read: 2,
-          missing_checked: 0,
-          doc_write_failures: 0,
-        }],
+        history: [
+          {
+            docs_written: 2,
+            docs_read: 2,
+            missing_checked: 0,
+            doc_write_failures: 0,
+          },
+        ],
       }),
     };
 
-    mockNano.mockReturnValue({ db: mockDb } as any);
+    mockNano.mockReturnValue({ db: mockDb } as unknown as ReturnType<typeof nano>);
 
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('Process exit called');
@@ -173,7 +179,7 @@ describe('replicate', () => {
 
     try {
       await replicate();
-    } catch (error) {
+    } catch (_error) {
       // Expected if process.exit is called
     }
 
@@ -187,7 +193,7 @@ describe('replicate', () => {
   it('should exit with error if source database does not exist', async () => {
     // Mock command line arguments
     process.argv = ['node', 'replicate.ts', 'nonexistent-db', 'target-db'];
-    
+
     // Mock database existence check - source does not exist
     mockCheckDatabaseExists.mockResolvedValueOnce({ exists: false, docCount: 0 });
 
@@ -197,7 +203,7 @@ describe('replicate', () => {
 
     try {
       await replicate();
-    } catch (error) {
+    } catch (_error) {
       expect(error.message).toBe('Process exit called');
     }
 
@@ -207,27 +213,27 @@ describe('replicate', () => {
   it('should exit with error if required arguments are missing', async () => {
     // Mock command line arguments - missing target
     process.argv = ['node', 'replicate.ts', 'source-db'];
-    
+
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('Process exit called');
     });
 
     try {
       await replicate();
-    } catch (error) {
+    } catch (_error) {
       expect(error.message).toBe('Process exit called');
     }
 
     expect(exitSpy).toHaveBeenCalledWith(1);
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Both source and target database names are required')
+      expect.stringContaining('Both source and target database names are required'),
     );
   });
 
   it('should handle replication errors gracefully', async () => {
     // Mock command line arguments
     process.argv = ['node', 'replicate.ts', 'source-db', 'target-db'];
-    
+
     // Mock database existence checks
     mockCheckDatabaseExists
       .mockResolvedValueOnce({ exists: true, docCount: 10 })
@@ -242,7 +248,7 @@ describe('replicate', () => {
       }),
     };
 
-    mockNano.mockReturnValue({ db: mockDb } as any);
+    mockNano.mockReturnValue({ db: mockDb } as unknown as ReturnType<typeof nano>);
 
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('Process exit called');
@@ -250,7 +256,7 @@ describe('replicate', () => {
 
     try {
       await replicate();
-    } catch (error) {
+    } catch (_error) {
       // Expected if process.exit is called
     }
 

--- a/scripts/backup-interactive.test.ts
+++ b/scripts/backup-interactive.test.ts
@@ -3,8 +3,7 @@
  * Run manually with: npx tsx scripts/backup-interactive.test.ts
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import fs from 'fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getBackupConfig } from './backup-interactive.js';
 
 // Mock dependencies
@@ -72,7 +71,7 @@ describe('backup-interactive', () => {
         timeout: 60000,
         dryRun: false,
       });
-      
+
       expect(prompts.default).toHaveBeenCalledWith(
         expect.arrayContaining([
           expect.objectContaining({ name: 'database' }),
@@ -80,7 +79,7 @@ describe('backup-interactive', () => {
           expect.objectContaining({ name: 'parallelism' }),
           expect.objectContaining({ name: 'timeout' }),
         ]),
-        expect.any(Object)
+        expect.any(Object),
       );
     });
 
@@ -99,15 +98,13 @@ describe('backup-interactive', () => {
       await getBackupConfig(options);
 
       expect(prompts.default).toHaveBeenCalledWith(
-        expect.arrayContaining([
-          expect.objectContaining({ name: 'backupDir' }),
-        ]),
-        expect.any(Object)
+        expect.arrayContaining([expect.objectContaining({ name: 'backupDir' })]),
+        expect.any(Object),
       );
-      
+
       // Should not prompt for already provided values
-      const calls = vi.mocked(prompts.default).mock.calls[0][0] as any[];
-      const promptNames = calls.map(call => call.name);
+      const calls = vi.mocked(prompts.default).mock.calls[0][0] as unknown[];
+      const promptNames = calls.map((call) => call.name);
       expect(promptNames).not.toContain('database');
       expect(promptNames).not.toContain('parallelism');
       expect(promptNames).not.toContain('timeout');
@@ -118,7 +115,7 @@ describe('backup-interactive', () => {
       const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
         throw new Error('Process exit called');
       });
-      
+
       const mockCancel = vi.fn(() => {
         console.log('Backup cancelled.');
         process.exit(0);
@@ -146,9 +143,9 @@ describe('backup-interactive', () => {
 
       await getBackupConfig({});
 
-      const calls = vi.mocked(prompts.default).mock.calls[0][0] as any[];
-      const parallelismPrompt = calls.find(call => call.name === 'parallelism');
-      
+      const calls = vi.mocked(prompts.default).mock.calls[0][0] as unknown[];
+      const parallelismPrompt = calls.find((call) => call.name === 'parallelism');
+
       expect(parallelismPrompt).toBeDefined();
       expect(parallelismPrompt.min).toBe(1);
       expect(parallelismPrompt.max).toBe(10);
@@ -165,9 +162,9 @@ describe('backup-interactive', () => {
 
       await getBackupConfig({});
 
-      const calls = vi.mocked(prompts.default).mock.calls[0][0] as any[];
-      const timeoutPrompt = calls.find(call => call.name === 'timeout');
-      
+      const calls = vi.mocked(prompts.default).mock.calls[0][0] as unknown[];
+      const timeoutPrompt = calls.find((call) => call.name === 'timeout');
+
       expect(timeoutPrompt).toBeDefined();
       expect(timeoutPrompt.min).toBe(10000);
     });

--- a/scripts/cleanup-interactive.ts
+++ b/scripts/cleanup-interactive.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env tsx
 
-import { Command } from 'commander';
-import prompts from 'prompts';
 import chalk from 'chalk';
-import ora from 'ora';
+import { Command } from 'commander';
 import nano from 'nano';
-import { validateEnv, getCouchDbConfig } from '../packages/core-server/src/config/env.js';
+import ora from 'ora';
+import prompts from 'prompts';
+import { getCouchDbConfig, validateEnv } from '../packages/core-server/src/config/env.js';
 
 interface CleanupConfig {
   mode: 'all' | 'pattern' | 'age' | 'custom';
@@ -45,7 +45,7 @@ async function main() {
     // Environment configuration using shared validation
     const env = validateEnv(process.env);
     const couchConfig = getCouchDbConfig(env);
-    
+
     // Auto-detect mode based on provided options
     let mode: CleanupConfig['mode'] = options.mode as CleanupConfig['mode'];
     if (options.pattern && mode === 'all') {
@@ -54,7 +54,7 @@ async function main() {
     if (options.databases && mode === 'all') {
       mode = 'custom';
     }
-    
+
     const config: CleanupConfig = {
       mode,
       pattern: options.pattern,
@@ -65,28 +65,34 @@ async function main() {
     };
 
     if (!config.force) {
-      console.log(chalk.yellow('⚠️  This tool will delete databases. Make sure you have backups if needed.\n'));
+      console.log(
+        chalk.yellow(
+          '⚠️  This tool will delete databases. Make sure you have backups if needed.\n',
+        ),
+      );
     }
 
     await runCleanup(couchConfig, config);
   } catch (error) {
     console.error(chalk.red('\nError:'), error instanceof Error ? error.message : String(error));
-    
+
     if (error instanceof Error) {
       if (error.message.includes('ECONNREFUSED')) {
         console.error(chalk.yellow('\nℹ️  Make sure CouchDB is running and accessible'));
       } else if (error.message.includes('unauthorized')) {
-        console.error(chalk.yellow('\nℹ️  Check your CouchDB credentials in the environment variables'));
+        console.error(
+          chalk.yellow('\nℹ️  Check your CouchDB credentials in the environment variables'),
+        );
       }
     }
-    
+
     process.exit(1);
   }
 }
 
 async function runCleanup(couchConfig: { url: string; dbName: string }, config: CleanupConfig) {
   const couch = nano(couchConfig.url);
-  
+
   // Discover available databases
   const spinner = ora('Discovering databases...').start();
   const allDatabases = await getAvailableDatabases(couchConfig.url);
@@ -94,17 +100,19 @@ async function runCleanup(couchConfig: { url: string; dbName: string }, config: 
 
   // Get database info for all databases
   const databaseInfos = await getDatabaseInfos(couchConfig.url, allDatabases);
-  
+
   // Filter databases based on cleanup config
   const targetDatabases = await filterDatabases(databaseInfos, config);
-  
+
   if (targetDatabases.length === 0) {
     console.log(chalk.green('\n✅ No databases match the cleanup criteria'));
     return;
   }
 
   // Show what will be cleaned up
-  console.log(chalk.cyan(`\n📋 Databases to ${config.dryRun ? 'be cleaned (dry-run)' : 'clean up'}:`));
+  console.log(
+    chalk.cyan(`\n📋 Databases to ${config.dryRun ? 'be cleaned (dry-run)' : 'clean up'}:`),
+  );
   targetDatabases.forEach((db, index) => {
     const sizeStr = (db.diskSize / 1024 / 1024).toFixed(2);
     console.log(`  ${index + 1}. ${db.name} (${db.docCount} docs, ${sizeStr} MB)`);
@@ -137,9 +145,10 @@ async function runCleanup(couchConfig: { url: string; dbName: string }, config: 
 async function getAvailableDatabases(couchdbUrl: string): Promise<string[]> {
   const url = new URL(couchdbUrl);
   const baseUrl = `${url.protocol}//${url.host}`;
-  const credentials = url.username && url.password 
-    ? Buffer.from(`${url.username}:${url.password}`).toString('base64')
-    : null;
+  const credentials =
+    url.username && url.password
+      ? Buffer.from(`${url.username}:${url.password}`).toString('base64')
+      : null;
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -150,13 +159,13 @@ async function getAvailableDatabases(couchdbUrl: string): Promise<string[]> {
   }
 
   const response = await fetch(`${baseUrl}/_all_dbs`, { headers });
-  
+
   if (!response.ok) {
     throw new Error(`Failed to fetch databases: ${response.status} ${response.statusText}`);
   }
-  
+
   const databases: string[] = await response.json();
-  
+
   // Filter out system databases (those starting with _)
   return databases.filter((db) => !db.startsWith('_'));
 }
@@ -164,9 +173,10 @@ async function getAvailableDatabases(couchdbUrl: string): Promise<string[]> {
 async function getDatabaseInfos(couchdbUrl: string, databases: string[]): Promise<DatabaseInfo[]> {
   const url = new URL(couchdbUrl);
   const baseUrl = `${url.protocol}//${url.host}`;
-  const credentials = url.username && url.password 
-    ? Buffer.from(`${url.username}:${url.password}`).toString('base64')
-    : null;
+  const credentials =
+    url.username && url.password
+      ? Buffer.from(`${url.username}:${url.password}`).toString('base64')
+      : null;
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -196,7 +206,11 @@ async function getDatabaseInfos(couchdbUrl: string, databases: string[]): Promis
       }
     } catch (error) {
       // Skip databases we can't access
-      console.warn(chalk.yellow(`⚠️  Could not access database '${dbName}': ${error instanceof Error ? error.message : String(error)}`));
+      console.warn(
+        chalk.yellow(
+          `⚠️  Could not access database '${dbName}': ${error instanceof Error ? error.message : String(error)}`,
+        ),
+      );
     }
   }
 
@@ -204,39 +218,37 @@ async function getDatabaseInfos(couchdbUrl: string, databases: string[]): Promis
 }
 
 function isTestDatabase(dbName: string): boolean {
-  const testPatterns = [
-    /^eddo_test_/,
-    /^test-/,
-    /^todos-test/,
-    /^test_/,
-  ];
+  const testPatterns = [/^eddo_test_/, /^test-/, /^todos-test/, /^test_/];
 
-  return testPatterns.some(pattern => pattern.test(dbName));
+  return testPatterns.some((pattern) => pattern.test(dbName));
 }
 
-async function filterDatabases(databaseInfos: DatabaseInfo[], config: CleanupConfig): Promise<DatabaseInfo[]> {
+async function filterDatabases(
+  databaseInfos: DatabaseInfo[],
+  config: CleanupConfig,
+): Promise<DatabaseInfo[]> {
   let filtered = databaseInfos;
 
   if (config.mode === 'all') {
     // Only include test databases
-    filtered = filtered.filter(db => db.isTestDatabase);
+    filtered = filtered.filter((db) => db.isTestDatabase);
   } else if (config.mode === 'pattern' && config.pattern) {
     // Convert glob pattern to regex
     const regexPattern = config.pattern
-      .replace(/\*/g, '.*')  // * becomes .*
-      .replace(/\?/g, '.')   // ? becomes .
-      .replace(/\./g, '\\.')  // Escape literal dots
+      .replace(/\*/g, '.*') // * becomes .*
+      .replace(/\?/g, '.') // ? becomes .
+      .replace(/\./g, '\\.') // Escape literal dots
       .replace(/\\\.\*/g, '.*'); // Restore .* for our * conversion
-    
+
     const regex = new RegExp(`^${regexPattern}$`);
-    filtered = filtered.filter(db => regex.test(db.name));
+    filtered = filtered.filter((db) => regex.test(db.name));
   } else if (config.mode === 'custom' && config.databases) {
-    filtered = filtered.filter(db => config.databases!.includes(db.name));
+    filtered = filtered.filter((db) => config.databases!.includes(db.name));
   }
 
   // If not in interactive mode, let user refine selection
   if (!config.force && filtered.length > 0) {
-    const choices = filtered.map(db => ({
+    const choices = filtered.map((db) => ({
       title: `${db.name} (${db.docCount} docs)`,
       value: db.name,
       selected: true,
@@ -254,7 +266,7 @@ async function filterDatabases(databaseInfos: DatabaseInfo[], config: CleanupCon
       return [];
     }
 
-    filtered = filtered.filter(db => selectedDatabases.includes(db.name));
+    filtered = filtered.filter((db) => selectedDatabases.includes(db.name));
   }
 
   return filtered;
@@ -262,7 +274,7 @@ async function filterDatabases(databaseInfos: DatabaseInfo[], config: CleanupCon
 
 async function performCleanup(couch: nano.ServerScope, databases: DatabaseInfo[]): Promise<void> {
   const spinner = ora('Cleaning up databases...').start();
-  
+
   let deletedCount = 0;
   let failedCount = 0;
 
@@ -273,16 +285,20 @@ async function performCleanup(couch: nano.ServerScope, databases: DatabaseInfo[]
       spinner.text = `Deleted ${deletedCount}/${databases.length} databases...`;
     } catch (error) {
       failedCount++;
-      console.warn(chalk.yellow(`⚠️  Failed to delete '${db.name}': ${error instanceof Error ? error.message : String(error)}`));
+      console.warn(
+        chalk.yellow(
+          `⚠️  Failed to delete '${db.name}': ${error instanceof Error ? error.message : String(error)}`,
+        ),
+      );
     }
   }
 
   spinner.succeed(`Cleanup complete: ${deletedCount} deleted, ${failedCount} failed`);
-  
+
   if (deletedCount > 0) {
     console.log(chalk.green(`\n✅ Successfully deleted ${deletedCount} database(s)`));
   }
-  
+
   if (failedCount > 0) {
     console.log(chalk.yellow(`\n⚠️  Failed to delete ${failedCount} database(s)`));
   }

--- a/scripts/cleanup-leftover-test-databases.ts
+++ b/scripts/cleanup-leftover-test-databases.ts
@@ -4,16 +4,16 @@
  * This script cleans up test databases that were created by tests but not properly cleaned up
  */
 
-import { cleanupDatabasesByPattern, validateEnv, getTestCouchDbConfig } from '@eddo/core-server';
+import { cleanupDatabasesByPattern, getTestCouchDbConfig, validateEnv } from '@eddo/core-server';
 
 async function main() {
   console.log('🧹 Cleaning up leftover test databases...');
-  
+
   try {
     // Use test environment configuration
     const env = validateEnv(process.env);
-    const testCouchConfig = getTestCouchDbConfig(env);
-    
+    const _testCouchConfig = getTestCouchDbConfig(env);
+
     // Clean up databases with test- prefix
     const testDatabasePattern = /^test-/;
     const result = await cleanupDatabasesByPattern(testDatabasePattern, {
@@ -22,26 +22,27 @@ async function main() {
       verbose: true,
       force: true, // Force cleanup for test databases
     });
-    
+
     console.log(`\n📊 Cleanup Summary:`);
     console.log(`  Total databases analyzed: ${result.summary.total}`);
     console.log(`  Cleaned up: ${result.summary.cleaned}`);
     console.log(`  Skipped: ${result.summary.skipped}`);
     console.log(`  Errors: ${result.summary.errors}`);
-    
+
     if (result.errors.length > 0) {
       console.warn(`\n⚠️  Some databases could not be cleaned up:`);
-      result.errors.forEach(error => {
+      result.errors.forEach((error) => {
         console.warn(`  - ${error.database}: ${error.error}`);
       });
     }
-    
+
     if (result.summary.cleaned > 0) {
-      console.log(`\n✅ Successfully cleaned up ${result.summary.cleaned} leftover test databases.`);
+      console.log(
+        `\n✅ Successfully cleaned up ${result.summary.cleaned} leftover test databases.`,
+      );
     } else {
       console.log(`\n✅ No leftover test databases found to clean up.`);
     }
-    
   } catch (error) {
     console.error('❌ Error during cleanup:', error);
     process.exit(1);

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -5,11 +5,11 @@
  * Discovers and orchestrates available commands
  */
 
-import { Command } from 'commander';
-import prompts from 'prompts';
 import chalk from 'chalk';
+import { Command } from 'commander';
 import fs from 'fs';
 import path from 'path';
+import prompts from 'prompts';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -52,13 +52,15 @@ const SCRIPTS: Record<string, ScriptInfo> = {
 
 async function listAvailableScripts(): Promise<void> {
   console.log(chalk.blue('\n📋 Available EdDoApp Scripts\n'));
-  
+
   Object.values(SCRIPTS).forEach((script) => {
     const status = fs.existsSync(path.join(__dirname, script.file)) ? '✅' : '❌';
     const interactive = script.hasInteractive ? chalk.gray('(interactive)') : '';
-    console.log(`  ${status} ${chalk.cyan(script.name.padEnd(20))} ${script.description} ${interactive}`);
+    console.log(
+      `  ${status} ${chalk.cyan(script.name.padEnd(20))} ${script.description} ${interactive}`,
+    );
   });
-  
+
   console.log('\nUsage:');
   console.log(`  ${chalk.gray('pnpm cli <script-name> [options]')}`);
   console.log(`  ${chalk.gray('pnpm cli                     # Interactive mode')}`);
@@ -67,10 +69,10 @@ async function listAvailableScripts(): Promise<void> {
 
 async function runInteractiveMode(): Promise<void> {
   console.log(chalk.blue('\n🚀 EdDoApp CLI - Interactive Mode\n'));
-  
+
   // Filter to only show existing scripts
   const availableScripts = Object.values(SCRIPTS).filter((script) =>
-    fs.existsSync(path.join(__dirname, script.file))
+    fs.existsSync(path.join(__dirname, script.file)),
   );
 
   if (availableScripts.length === 0) {
@@ -99,7 +101,7 @@ async function runInteractiveMode(): Promise<void> {
 
 async function runScript(scriptName: string, args: string[]): Promise<void> {
   const script = SCRIPTS[scriptName];
-  
+
   if (!script) {
     console.error(chalk.red(`Unknown script: ${scriptName}`));
     console.log('\nAvailable scripts:');
@@ -110,7 +112,7 @@ async function runScript(scriptName: string, args: string[]): Promise<void> {
   }
 
   const scriptPath = path.join(__dirname, script.file);
-  
+
   if (!fs.existsSync(scriptPath)) {
     console.error(chalk.red(`Script file not found: ${scriptPath}`));
     process.exit(1);
@@ -122,7 +124,7 @@ async function runScript(scriptName: string, args: string[]): Promise<void> {
   try {
     // Dynamic import and execution
     const module = await import(scriptPath);
-    
+
     // Most scripts are designed to run when imported, but we can also
     // call specific functions if they export them
     if (scriptName === 'backup' && module.performBackup) {
@@ -132,7 +134,7 @@ async function runScript(scriptName: string, args: string[]): Promise<void> {
         stdio: 'inherit',
         cwd: process.cwd(),
       });
-      
+
       child.on('exit', (code) => {
         process.exit(code || 0);
       });
@@ -143,7 +145,7 @@ async function runScript(scriptName: string, args: string[]): Promise<void> {
         stdio: 'inherit',
         cwd: process.cwd(),
       });
-      
+
       child.on('exit', (code) => {
         process.exit(code || 0);
       });
@@ -184,16 +186,17 @@ program
   });
 
 // Handle help command specially
-program.command('help [command]')
+program
+  .command('help [command]')
   .description('display help for command')
   .action(async (command) => {
     if (command && SCRIPTS[command]) {
       const script = SCRIPTS[command];
       console.log(chalk.blue(`\n${script.name} - ${script.description}\n`));
-      
+
       // Run the script with --help to show its specific help
       const { spawn } = await import('child_process');
-      const child = spawn('tsx', [path.join(__dirname, script.file), '--help'], {
+      const _child = spawn('tsx', [path.join(__dirname, script.file), '--help'], {
         stdio: 'inherit',
       });
     } else {
@@ -206,4 +209,4 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   program.parse();
 }
 
-export { runScript, listAvailableScripts };
+export { listAvailableScripts, runScript };

--- a/scripts/populate-mock-data.ts
+++ b/scripts/populate-mock-data.ts
@@ -5,24 +5,24 @@
  * Creates GTD todos for a typical week of a Starfleet officer
  */
 
-import fetch from 'node-fetch';
-import { validateEnv, getCouchDbConfig } from '@eddo/core-server/config';
+import { getCouchDbConfig, validateEnv } from '@eddo/core-server/config';
 import type { TodoAlpha3 } from '@eddo/core-server/types/todo';
+import fetch from 'node-fetch';
 
 // Environment configuration using shared validation
 const env = validateEnv(process.env);
 const couchConfig = getCouchDbConfig(env);
 
 // GTD Contexts for a Starfleet officer
-type StarfleetContext = 
-  | 'bridge'      // Bridge duties and command responsibilities  
+type StarfleetContext =
+  | 'bridge' // Bridge duties and command responsibilities
   | 'engineering' // Technical tasks and system maintenance
-  | 'away-team'   // Away missions and exploration
-  | 'personal'    // Personal development and relationships
-  | 'starfleet'   // Starfleet administration and protocols
-  | 'science'     // Research and analysis tasks
-  | 'diplomatic'  // Diplomatic and first contact duties
-  | 'training';   // Crew training and development
+  | 'away-team' // Away missions and exploration
+  | 'personal' // Personal development and relationships
+  | 'starfleet' // Starfleet administration and protocols
+  | 'science' // Research and analysis tasks
+  | 'diplomatic' // Diplomatic and first contact duties
+  | 'training'; // Crew training and development
 
 interface TodoTemplate {
   title: string;
@@ -63,56 +63,120 @@ function generateStarfleetTodos(): TodoAlpha3[] {
     { title: 'Conduct senior staff briefing', context: 'bridge', due: getDate(0, 9, 0) },
     { title: 'Analyze long-range sensor data', context: 'science', due: getDate(0, 14, 0) },
     { title: 'Submit crew performance evaluations', context: 'starfleet', due: getDate(0, 16, 0) },
-    { title: 'Review diplomatic protocols for Risa conference', context: 'diplomatic', due: getDate(0, 19, 0) },
+    {
+      title: 'Review diplomatic protocols for Risa conference',
+      context: 'diplomatic',
+      due: getDate(0, 19, 0),
+    },
 
-    // Tuesday - Engineering & System Maintenance  
-    { title: 'Inspect warp core containment field', context: 'engineering', due: getDate(1, 10, 0) },
+    // Tuesday - Engineering & System Maintenance
+    {
+      title: 'Inspect warp core containment field',
+      context: 'engineering',
+      due: getDate(1, 10, 0),
+    },
     { title: 'Calibrate deflector array sensors', context: 'engineering', due: getDate(1, 14, 30) },
-    { title: 'Approve engineering staff rotation schedule', context: 'starfleet', due: getDate(1, 11, 0) },
-    { title: 'Review quantum mechanics research proposal', context: 'science', due: getDate(1, 15, 0) },
+    {
+      title: 'Approve engineering staff rotation schedule',
+      context: 'starfleet',
+      due: getDate(1, 11, 0),
+    },
+    {
+      title: 'Review quantum mechanics research proposal',
+      context: 'science',
+      due: getDate(1, 15, 0),
+    },
     { title: 'Practice Vulcan meditation techniques', context: 'personal', due: getDate(1, 20, 0) },
 
     // Wednesday - Away Mission Prep
     { title: 'Prepare away team equipment manifest', context: 'away-team', due: getDate(2, 9, 30) },
-    { title: 'Briefing on Class M planet survey protocols', context: 'away-team', due: getDate(2, 11, 0) },
-    { title: 'Review xenobiology database for mission', context: 'science', due: getDate(2, 13, 0) },
+    {
+      title: 'Briefing on Class M planet survey protocols',
+      context: 'away-team',
+      due: getDate(2, 11, 0),
+    },
+    {
+      title: 'Review xenobiology database for mission',
+      context: 'science',
+      due: getDate(2, 13, 0),
+    },
     { title: 'Test universal translator updates', context: 'away-team', due: getDate(2, 15, 30) },
-    { title: 'Send subspace message to Admiral Paris', context: 'starfleet', due: getDate(2, 17, 0) },
+    {
+      title: 'Send subspace message to Admiral Paris',
+      context: 'starfleet',
+      due: getDate(2, 17, 0),
+    },
 
     // Thursday - Training & Development
     { title: 'Conduct phaser training simulation', context: 'training', due: getDate(3, 10, 0) },
-    { title: 'Review Starfleet Academy curriculum updates', context: 'training', due: getDate(3, 14, 0) },
-    { title: 'Mentor junior officer career development', context: 'training', due: getDate(3, 16, 0) },
-    { title: 'Complete temporal mechanics certification', context: 'training', due: getDate(3, 19, 0) },
+    {
+      title: 'Review Starfleet Academy curriculum updates',
+      context: 'training',
+      due: getDate(3, 14, 0),
+    },
+    {
+      title: 'Mentor junior officer career development',
+      context: 'training',
+      due: getDate(3, 16, 0),
+    },
+    {
+      title: 'Complete temporal mechanics certification',
+      context: 'training',
+      due: getDate(3, 19, 0),
+    },
     { title: 'Call parents on Earth', context: 'personal', due: getDate(3, 21, 0) },
 
     // Friday - Diplomatic & Science
     { title: 'First contact protocols workshop', context: 'diplomatic', due: getDate(4, 9, 0) },
     { title: 'Analyze subspace anomaly readings', context: 'science', due: getDate(4, 11, 30) },
     { title: 'Prepare report for Starfleet Command', context: 'starfleet', due: getDate(4, 15, 0) },
-    { title: 'Review trade negotiations with Ferengi', context: 'diplomatic', due: getDate(4, 17, 30) },
+    {
+      title: 'Review trade negotiations with Ferengi',
+      context: 'diplomatic',
+      due: getDate(4, 17, 30),
+    },
 
     // Weekend - Personal & Maintenance
     { title: 'Holodeck recreation program updates', context: 'personal', due: getDate(5, 10, 0) },
     { title: 'Monthly system diagnostics review', context: 'engineering', due: getDate(5, 14, 0) },
-    { title: 'Read "Advanced Warp Theory" by Dr. Brahms', context: 'personal', due: getDate(6, 16, 0) },
+    {
+      title: 'Read "Advanced Warp Theory" by Dr. Brahms',
+      context: 'personal',
+      due: getDate(6, 16, 0),
+    },
     { title: 'Chess match with Data in Ten Forward', context: 'personal', due: getDate(6, 19, 0) },
 
     // Recurring & Overdue Items
-    { title: 'Weekly replicator maintenance check', context: 'engineering', due: getDate(-2, 10, 0) }, // Overdue
+    {
+      title: 'Weekly replicator maintenance check',
+      context: 'engineering',
+      due: getDate(-2, 10, 0),
+    }, // Overdue
     { title: 'Update personal log entries', context: 'personal', due: getDate(1, 22, 0) },
     { title: 'Review bridge officer duty roster', context: 'bridge', due: getDate(2, 8, 0) },
-    { title: 'Coordinate with Engineering on shield upgrades', context: 'bridge', due: getDate(4, 13, 0) },
+    {
+      title: 'Coordinate with Engineering on shield upgrades',
+      context: 'bridge',
+      due: getDate(4, 13, 0),
+    },
 
     // Long-term projects
-    { title: 'Develop new first contact procedures', context: 'diplomatic', due: getDate(14, 12, 0) }, // Next week
-    { title: 'Write paper on quantum field fluctuations', context: 'science', due: getDate(21, 15, 0) }, // Future
+    {
+      title: 'Develop new first contact procedures',
+      context: 'diplomatic',
+      due: getDate(14, 12, 0),
+    }, // Next week
+    {
+      title: 'Write paper on quantum field fluctuations',
+      context: 'science',
+      due: getDate(21, 15, 0),
+    }, // Future
   ];
 
   // Convert to TodoAlpha3 format
   todoData.forEach((todo) => {
-    const createdTime = new Date(now.getTime() - (Math.random() * 7 * 24 * 60 * 60 * 1000)); // Random time in past week
-    
+    const createdTime = new Date(now.getTime() - Math.random() * 7 * 24 * 60 * 60 * 1000); // Random time in past week
+
     const todoAlpha3: TodoAlpha3 = {
       _id: createdTime.toISOString(),
       version: 'alpha3',
@@ -124,7 +188,7 @@ function generateStarfleetTodos(): TodoAlpha3[] {
       active: {},
       completed: Math.random() > 0.8 ? new Date().toISOString() : null, // 20% completed
       repeat: todo.title.includes('Weekly') ? 7 : null, // Weekly recurring items
-      link: null
+      link: null,
     };
 
     todos.push(todoAlpha3);
@@ -136,13 +200,13 @@ function generateStarfleetTodos(): TodoAlpha3[] {
 // Generate appropriate tags based on todo content and context
 function generateTagsForTodo(todo: TodoTemplate): string[] {
   const tags: string[] = [];
-  
+
   // Context-based tags
   switch (todo.context) {
     case 'bridge':
       tags.push('command', 'duty-shift');
       break;
-    case 'engineering':  
+    case 'engineering':
       tags.push('technical', 'maintenance');
       break;
     case 'away-team':
@@ -169,13 +233,19 @@ function generateTagsForTodo(todo: TodoTemplate): string[] {
   if (todo.title.toLowerCase().includes('report')) {
     tags.push('documentation');
   }
-  if (todo.title.toLowerCase().includes('briefing') || todo.title.toLowerCase().includes('meeting')) {
+  if (
+    todo.title.toLowerCase().includes('briefing') ||
+    todo.title.toLowerCase().includes('meeting')
+  ) {
     tags.push('meeting');
   }
   if (todo.title.toLowerCase().includes('review')) {
     tags.push('review');
   }
-  if (todo.title.toLowerCase().includes('training') || todo.title.toLowerCase().includes('practice')) {
+  if (
+    todo.title.toLowerCase().includes('training') ||
+    todo.title.toLowerCase().includes('practice')
+  ) {
     tags.push('skill-building');
   }
   if (todo.title.toLowerCase().includes('contact') || todo.title.toLowerCase().includes('call')) {
@@ -196,8 +266,8 @@ function getAuthHeaders(): Record<string, string> {
   if (url.username && url.password) {
     const auth = Buffer.from(`${url.username}:${url.password}`).toString('base64');
     return {
-      'Authorization': `Basic ${auth}`,
-      'Content-Type': 'application/json'
+      Authorization: `Basic ${auth}`,
+      'Content-Type': 'application/json',
     };
   }
   return { 'Content-Type': 'application/json' };
@@ -216,15 +286,15 @@ async function ensureDatabase(): Promise<void> {
   try {
     const cleanUrl = getCleanUrl();
     const headers = getAuthHeaders();
-    
+
     const response = await fetch(cleanUrl, { headers });
     if (response.status === 404) {
       console.log(`Creating database: ${couchConfig.dbName}`);
       const createResponse = await fetch(cleanUrl, {
         method: 'PUT',
-        headers
+        headers,
       });
-      
+
       if (!createResponse.ok) {
         throw new Error(`Failed to create database: ${createResponse.statusText}`);
       }
@@ -240,31 +310,31 @@ async function ensureDatabase(): Promise<void> {
 // Populate database with mock data
 async function populateMockData(): Promise<void> {
   const dryRun = process.argv.includes('--dry-run');
-  
+
   try {
     console.log(`Connecting to CouchDB at ${couchConfig.url}`);
     console.log(`Target database: ${couchConfig.dbName}`);
-    
+
     if (dryRun) {
       console.log('🧪 DRY RUN MODE - No data will be inserted');
     } else {
       await ensureDatabase();
     }
-    
+
     const todos = generateStarfleetTodos();
     console.log(`Generated ${todos.length} Starfleet officer todos`);
-    
+
     // Show context distribution
     const contextCounts: Record<string, number> = {};
     todos.forEach((todo) => {
       contextCounts[todo.context] = (contextCounts[todo.context] || 0) + 1;
     });
-    
+
     console.log('Todo distribution by context:');
     Object.entries(contextCounts).forEach(([context, count]) => {
       console.log(`  ${context}: ${count}`);
     });
-    
+
     if (dryRun) {
       // Show sample todos in dry run
       console.log('\n📝 Sample todos that would be created:');
@@ -279,39 +349,41 @@ async function populateMockData(): Promise<void> {
     } else {
       // Bulk insert todos
       const bulkDoc: BulkDocsRequest = {
-        docs: todos
+        docs: todos,
       };
-      
+
       const cleanUrl = getCleanUrl();
       const headers = getAuthHeaders();
-      
+
       const response = await fetch(`${cleanUrl}/_bulk_docs`, {
         method: 'POST',
         headers,
-        body: JSON.stringify(bulkDoc)
+        body: JSON.stringify(bulkDoc),
       });
-      
+
       if (!response.ok) {
         throw new Error(`Bulk insert failed: ${response.statusText}`);
       }
-      
-      const result = await response.json() as BulkDocsResponse[];
-      
+
+      const result = (await response.json()) as BulkDocsResponse[];
+
       // Check for errors
       const errors = result.filter((doc) => doc.error);
       if (errors.length > 0) {
         console.warn(`${errors.length} documents failed to insert:`);
         errors.forEach((error) => console.warn(`  ${error.id}: ${error.error}`));
       }
-      
+
       const successful = result.length - errors.length;
       console.log(`✅ Successfully inserted ${successful} todos`);
       console.log(`📅 Date range: ${new Date().toLocaleDateString()} week`);
       console.log(`🖖 Ready for a productive week in Starfleet!`);
     }
-    
   } catch (error) {
-    console.error('Mock data population failed:', error instanceof Error ? error.message : String(error));
+    console.error(
+      'Mock data population failed:',
+      error instanceof Error ? error.message : String(error),
+    );
     process.exit(1);
   }
 }

--- a/scripts/replicate-interactive.ts
+++ b/scripts/replicate-interactive.ts
@@ -5,12 +5,12 @@
  * Supports both interactive prompts and direct command-line arguments
  */
 
-import { Command } from 'commander';
-import prompts from 'prompts';
-import ora from 'ora';
+import { getAvailableDatabases, getCouchDbConfig, validateEnv } from '@eddo/core-server/config';
 import chalk from 'chalk';
+import { Command } from 'commander';
 import nano from 'nano';
-import { validateEnv, getCouchDbConfig, getAvailableDatabases } from '@eddo/core-server/config';
+import ora from 'ora';
+import prompts from 'prompts';
 import { checkDatabaseExists, formatDuration } from './backup-utils.js';
 
 interface ReplicationConfig {
@@ -20,11 +20,13 @@ interface ReplicationConfig {
   createTarget: boolean;
 }
 
-async function getReplicationConfig(options: Partial<ReplicationConfig>): Promise<ReplicationConfig> {
+async function getReplicationConfig(
+  options: Partial<ReplicationConfig>,
+): Promise<ReplicationConfig> {
   // Environment configuration
   const env = validateEnv(process.env);
-  const couchConfig = getCouchDbConfig(env);
-  
+  const _couchConfig = getCouchDbConfig(env);
+
   // Default values
   const defaults: ReplicationConfig = {
     continuous: false,
@@ -38,20 +40,20 @@ async function getReplicationConfig(options: Partial<ReplicationConfig>): Promis
 
   // Otherwise, prompt for missing values
   console.log(chalk.blue('\n🔄 CouchDB Interactive Replication\n'));
-  
+
   // Discover available databases
   const spinner = ora('Discovering available databases...').start();
   const availableDatabases = await getAvailableDatabases(env);
   spinner.stop();
 
   const questions: prompts.PromptObject[] = [];
-  
+
   // Source database selection
   if (!options.source) {
     if (availableDatabases.length === 0) {
       console.log(chalk.yellow('⚠️  No databases found or unable to connect to CouchDB'));
       console.log(chalk.gray('Falling back to manual input...'));
-      
+
       questions.push({
         type: 'text',
         name: 'source',
@@ -60,9 +62,9 @@ async function getReplicationConfig(options: Partial<ReplicationConfig>): Promis
       });
     } else {
       console.log(chalk.green(`✅ Found ${availableDatabases.length} database(s)\n`));
-      
+
       const sourceChoices = [
-        ...availableDatabases.map(db => ({
+        ...availableDatabases.map((db) => ({
           title: db,
           value: db,
         })),
@@ -82,7 +84,7 @@ async function getReplicationConfig(options: Partial<ReplicationConfig>): Promis
 
       // If user selects custom, ask for manual input
       questions.push({
-        type: (prev) => prev === '__custom__' ? 'text' : null,
+        type: (prev) => (prev === '__custom__' ? 'text' : null),
         name: 'source',
         message: 'Enter source database name:',
         validate: (value: string) => value.length > 0 || 'Database name is required',
@@ -92,17 +94,20 @@ async function getReplicationConfig(options: Partial<ReplicationConfig>): Promis
 
   // Target database selection
   if (!options.target) {
-    const targetChoices = availableDatabases.length > 0 ? [
-      ...availableDatabases.map(db => ({
-        title: db,
-        value: db,
-      })),
-      {
-        title: '📝 Enter custom database name',
-        value: '__custom__',
-        description: 'Create new or use existing database',
-      },
-    ] : [];
+    const targetChoices =
+      availableDatabases.length > 0
+        ? [
+            ...availableDatabases.map((db) => ({
+              title: db,
+              value: db,
+            })),
+            {
+              title: '📝 Enter custom database name',
+              value: '__custom__',
+              description: 'Create new or use existing database',
+            },
+          ]
+        : [];
 
     if (targetChoices.length > 0) {
       questions.push({
@@ -122,7 +127,7 @@ async function getReplicationConfig(options: Partial<ReplicationConfig>): Promis
 
     // If user selects custom, ask for manual input
     questions.push({
-      type: (prev) => prev === '__custom__' ? 'text' : null,
+      type: (prev) => (prev === '__custom__' ? 'text' : null),
       name: 'target',
       message: 'Enter target database name:',
       validate: (value: string) => value.length > 0 || 'Database name is required',
@@ -138,7 +143,7 @@ async function getReplicationConfig(options: Partial<ReplicationConfig>): Promis
   });
 
   const answers = await prompts(questions);
-  
+
   // User cancelled
   if (!answers.source || !answers.target) {
     console.log(chalk.red('\n✗ Replication cancelled'));
@@ -157,28 +162,30 @@ async function performReplication(config: ReplicationConfig): Promise<void> {
     console.log(chalk.bold('\n📋 Replication Configuration:'));
     console.log(`Source: ${chalk.cyan(config.source)}`);
     console.log(`Target: ${chalk.cyan(config.target)}`);
-    console.log(`Mode: ${config.continuous ? chalk.yellow('Continuous') : chalk.green('One-time')}`);
+    console.log(
+      `Mode: ${config.continuous ? chalk.yellow('Continuous') : chalk.green('One-time')}`,
+    );
     console.log();
 
     // Check if source database exists
     spinner.start('Checking source database...');
     const sourceInfo = await checkDatabaseExists(config.source!, couchConfig.url);
-    
+
     if (!sourceInfo.exists) {
       spinner.fail(chalk.red(`Source database '${config.source}' does not exist`));
       process.exit(1);
     }
-    
+
     spinner.succeed(`Source database '${config.source}' found (${sourceInfo.docCount} documents)`);
 
     // Check if target database exists
     spinner.start('Checking target database...');
     const targetInfo = await checkDatabaseExists(config.target!, couchConfig.url);
-    
+
     if (!targetInfo.exists) {
       if (config.createTarget) {
         spinner.warn(chalk.yellow(`Target database '${config.target}' does not exist`));
-        
+
         // Create target database
         spinner.start(`Creating target database '${config.target}'...`);
         const couch = nano(couchConfig.url);
@@ -189,11 +196,15 @@ async function performReplication(config: ReplicationConfig): Promise<void> {
         process.exit(1);
       }
     } else {
-      spinner.succeed(`Target database '${config.target}' found (${targetInfo.docCount} documents)`);
-      
+      spinner.succeed(
+        `Target database '${config.target}' found (${targetInfo.docCount} documents)`,
+      );
+
       // Warn about existing data
       if (targetInfo.docCount > 0) {
-        console.log(chalk.yellow(`\n⚠️  Target database contains ${targetInfo.docCount} existing documents`));
+        console.log(
+          chalk.yellow(`\n⚠️  Target database contains ${targetInfo.docCount} existing documents`),
+        );
         console.log(chalk.gray('These will be preserved and updated/merged with source data\n'));
       }
     }
@@ -214,9 +225,9 @@ async function performReplication(config: ReplicationConfig): Promise<void> {
     // Start replication
     spinner.start('Starting replication...');
     const startTime = Date.now();
-    
+
     const couch = nano(couchConfig.url);
-    
+
     // Create replication options
     const replicationOpts: nano.DatabaseReplicateOptions = {
       create_target: false, // We handle this above
@@ -225,17 +236,17 @@ async function performReplication(config: ReplicationConfig): Promise<void> {
 
     // Perform replication
     const result = await couch.db.replicate(config.source!, config.target!, replicationOpts);
-    
+
     const duration = Date.now() - startTime;
     spinner.succeed(`Replication ${config.continuous ? 'started' : 'completed'} successfully`);
 
     // Display results
     console.log();
     console.log(chalk.bold('📊 Replication Summary:'));
-    
+
     if (result.ok) {
       console.log(`Status: ${chalk.green('✓ Success')}`);
-      
+
       if (result.history && result.history.length > 0) {
         const history = result.history[0];
         console.log(`Documents written: ${chalk.cyan(history.docs_written || 0)}`);
@@ -243,13 +254,13 @@ async function performReplication(config: ReplicationConfig): Promise<void> {
         console.log(`Missing documents: ${chalk.cyan(history.missing_checked || 0)}`);
         console.log(`Errors: ${chalk.red(history.doc_write_failures || 0)}`);
       }
-      
+
       if (config.continuous) {
         console.log(`\n${chalk.yellow('ℹ️  Continuous replication is running in the background')}`);
         console.log(`Replication ID: ${chalk.cyan(result._id || 'N/A')}`);
       } else {
         console.log(`Duration: ${chalk.cyan(formatDuration(duration))}`);
-        
+
         // Check final document count
         const finalTargetInfo = await checkDatabaseExists(config.target!, couchConfig.url);
         console.log(`\nTarget database now has ${chalk.cyan(finalTargetInfo.docCount)} documents`);
@@ -260,38 +271,39 @@ async function performReplication(config: ReplicationConfig): Promise<void> {
         console.log(`Errors: ${chalk.red(JSON.stringify(result.errors, null, 2))}`);
       }
     }
-
   } catch (error) {
     spinner.fail('Replication failed');
     console.error(chalk.red('\nError:'), error instanceof Error ? error.message : String(error));
-    
+
     // Provide helpful error messages
     if (error instanceof Error) {
       if (error.message.includes('ECONNREFUSED')) {
         console.error(chalk.yellow('\nℹ️  Make sure CouchDB is running and accessible'));
       } else if (error.message.includes('unauthorized')) {
-        console.error(chalk.yellow('\nℹ️  Check your CouchDB credentials in the environment variables'));
+        console.error(
+          chalk.yellow('\nℹ️  Check your CouchDB credentials in the environment variables'),
+        );
       }
     }
-    
+
     process.exit(1);
   }
 }
 
 async function main(): Promise<void> {
   const program = new Command();
-  
+
   program
     .name('replicate-interactive')
     .description('Interactive CouchDB replication tool')
     .option('-s, --source <database>', 'source database name')
     .option('-t, --target <database>', 'target database name')
     .option('-c, --continuous', 'enable continuous replication', false)
-    .option('--no-create-target', 'do not create target database if it doesn\'t exist')
+    .option('--no-create-target', "do not create target database if it doesn't exist")
     .parse(process.argv);
 
   const options = program.opts<Partial<ReplicationConfig>>();
-  
+
   try {
     const config = await getReplicationConfig(options);
     await performReplication(config);

--- a/scripts/run-integration-tests.js
+++ b/scripts/run-integration-tests.js
@@ -12,16 +12,14 @@ async function runIntegrationTests() {
   try {
     // Start the MCP server
     console.log('🚀 Starting MCP test server...');
-    serverProcess = spawn('pnpm', [
-      '--filter', '@eddo/mcp-server', 'start:test'
-    ], {
+    serverProcess = spawn('pnpm', ['--filter', '@eddo/mcp-server', 'start:test'], {
       env: {
         ...process.env,
         COUCHDB_TEST_DB_NAME: 'todos-test',
         MCP_TEST_PORT: '3003',
-        NODE_ENV: 'test'
+        NODE_ENV: 'test',
       },
-      stdio: ['ignore', 'pipe', 'pipe']
+      stdio: ['ignore', 'pipe', 'pipe'],
     });
 
     // Pipe server output but filter out the exit error
@@ -45,7 +43,7 @@ async function runIntegrationTests() {
     // Run the tests
     console.log('🧪 Running integration tests...');
     const testProcess = spawn('vitest', ['run', 'packages/mcp_server/src/integration-tests'], {
-      stdio: 'inherit'
+      stdio: 'inherit',
     });
 
     // Wait for tests to complete
@@ -55,16 +53,15 @@ async function runIntegrationTests() {
         resolve();
       });
     });
-
   } finally {
     // Clean up the server process
     if (serverProcess) {
       console.log('🛑 Stopping MCP test server...');
       serverProcess.kill('SIGTERM');
-      
+
       // Give it a moment to shut down gracefully
       await setTimeout(500);
-      
+
       // Force kill if still running
       if (!serverProcess.killed) {
         serverProcess.kill('SIGKILL');

--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -5,9 +5,9 @@
  * Tests basic configuration and validation without actual backup
  */
 
+import { getAvailableDatabases, validateEnv } from '@eddo/core-server/config';
 import chalk from 'chalk';
 import { getBackupConfig } from './backup-interactive.js';
-import { validateEnv, getAvailableDatabases } from '@eddo/core-server/config';
 
 async function testDatabaseDiscovery(): Promise<void> {
   console.log(chalk.blue('\n🧪 Testing Database Discovery\n'));
@@ -15,9 +15,9 @@ async function testDatabaseDiscovery(): Promise<void> {
   try {
     const env = validateEnv(process.env);
     console.log(chalk.cyan('Discovering available databases...'));
-    
+
     const databases = await getAvailableDatabases(env);
-    
+
     if (databases.length === 0) {
       console.log(chalk.yellow('⚠️  No databases found or unable to connect to CouchDB'));
       console.log(chalk.gray('Make sure CouchDB is running and accessible'));
@@ -45,7 +45,7 @@ async function testConfigGeneration(): Promise<void> {
       timeout: 30000,
       dryRun: true,
     });
-    
+
     console.log('✅ Full config test passed');
     console.log(`   Database: ${fullConfig.database}`);
     console.log(`   Backup Dir: ${fullConfig.backupDir}`);
@@ -56,7 +56,7 @@ async function testConfigGeneration(): Promise<void> {
     // Test 2: Partial configuration (this will prompt interactively)
     console.log(chalk.cyan('\nTest 2: Interactive mode (will prompt)'));
     console.log(chalk.gray('Run with --no-interactive to skip this test'));
-    
+
     if (!process.argv.includes('--no-interactive')) {
       const interactiveConfig = await getBackupConfig({
         database: 'interactive-test',
@@ -68,7 +68,6 @@ async function testConfigGeneration(): Promise<void> {
     }
 
     console.log(chalk.green('\n✅ All CLI tests passed!'));
-    
   } catch (error) {
     console.error(chalk.red('❌ Test failed:'), error);
     process.exit(1);
@@ -77,14 +76,14 @@ async function testConfigGeneration(): Promise<void> {
 
 async function testCLIHelp(): Promise<void> {
   console.log(chalk.blue('\n🧪 Testing CLI Help Output\n'));
-  
+
   const { spawn } = await import('child_process');
-  
+
   console.log(chalk.cyan('Testing backup-interactive --help:'));
   const backupHelpProcess = spawn('tsx', ['scripts/backup-interactive.ts', '--help'], {
     stdio: 'inherit',
   });
-  
+
   backupHelpProcess.on('close', (code) => {
     if (code === 0) {
       console.log(chalk.green('✅ Backup help command works'));
@@ -97,7 +96,7 @@ async function testCLIHelp(): Promise<void> {
   const restoreHelpProcess = spawn('tsx', ['scripts/restore-interactive.ts', '--help'], {
     stdio: 'inherit',
   });
-  
+
   restoreHelpProcess.on('close', (code) => {
     if (code === 0) {
       console.log(chalk.green('✅ Restore help command works'));
@@ -116,15 +115,15 @@ const testHelp = args.includes('--help-test') || args.length === 0;
 if (import.meta.url === `file://${process.argv[1]}`) {
   console.log(chalk.blue('🚀 CLI Testing Suite'));
   console.log(chalk.gray('Options: --database, --config, --help-test, --no-interactive\n'));
-  
+
   if (testDatabase) {
     await testDatabaseDiscovery();
   }
-  
+
   if (testConfig) {
     await testConfigGeneration();
   }
-  
+
   if (testHelp) {
     await testCLIHelp();
   }

--- a/scripts/test-mcp.js
+++ b/scripts/test-mcp.js
@@ -43,7 +43,7 @@ async function testMcpTool(toolName, args = {}) {
         capabilities: {
           tools: {},
         },
-      }
+      },
     );
 
     console.log('🔌 Connecting to MCP server...');
@@ -53,10 +53,10 @@ async function testMcpTool(toolName, args = {}) {
     console.log('🔍 Discovering available tools...');
     const toolsResponse = await client.listTools();
     console.log(`📋 Found ${toolsResponse.tools.length} tools`);
-    
+
     // List available tools
     console.log('Available tools:');
-    toolsResponse.tools.forEach(tool => {
+    toolsResponse.tools.forEach((tool) => {
       console.log(`  - ${tool.name}: ${tool.description}`);
     });
     console.log('');
@@ -84,7 +84,6 @@ async function testMcpTool(toolName, args = {}) {
     }
 
     console.log('='.repeat(80));
-
   } catch (error) {
     console.error('❌ Test failed:', error.message);
     if (error.stack) {

--- a/scripts/version-packages.js
+++ b/scripts/version-packages.js
@@ -1,6 +1,20 @@
 #!/usr/bin/env node
 import { execSync } from 'child_process';
+import { existsSync, readdirSync, unlinkSync } from 'fs';
+import { join } from 'path';
 
 // Run changeset version
 // Git operations (add/commit) are handled by changesets/action
 execSync('pnpm changeset version', { stdio: 'inherit' });
+
+// Clean up completed todos in spec/todos/done/
+const donePath = 'spec/todos/done';
+if (existsSync(donePath)) {
+  const doneFiles = readdirSync(donePath).filter((f) => f.endsWith('.md'));
+  console.log(`Removing ${doneFiles.length} completed todo(s)...`);
+  doneFiles.forEach((file) => {
+    const filePath = join(donePath, file);
+    unlinkSync(filePath);
+    console.log(`  Removed: ${filePath}`);
+  });
+}


### PR DESCRIPTION
## Changes

**Fixed linting mismatch between `pnpm lint` and pre-commit hook**
- Extended `pnpm lint` to check both `./packages` and `./scripts` directories
- Previously only checked `./packages`, now matches `.lintstagedrc.json` configuration

**Resolved all 161 linting errors**
- Added Node.js globals configuration for `scripts/**/*.js` files (console, process, URL, Buffer)
- Removed unused imports and type definitions (BackupOptions, RestoreOptions, DatabaseInfo, formatDuration)
- Prefixed unused variables with underscore per ESLint rules
- Replaced `any` types with proper types (`unknown`, `Record<string, unknown>[]`)

**Added cleanup of completed todos to release process**
- Updated `scripts/version-packages.js` to remove `spec/todos/done/*.md` files during release
- Currently 36 completed todos will be removed on next release

## Result
- 0 errors (down from 161)
- 181 warnings (complexity/size guards set to warn for gradual improvement per CLAUDE.md)