### PR TITLE
feat: move status column to first position in todo table

### DIFF
--- a/packages/web-client/src/components/todo_table.test.tsx
+++ b/packages/web-client/src/components/todo_table.test.tsx
@@ -160,7 +160,7 @@ describe('TodoTable', () => {
       await waitFor(() => {
         expect(screen.getByText('Title')).toBeInTheDocument();
         expect(screen.getByText('Due Date')).toBeInTheDocument();
-        expect(screen.getByText('Status')).toBeInTheDocument();
+        expect(screen.getByRole('checkbox')).toBeInTheDocument();
         expect(screen.queryByText('Tags')).not.toBeInTheDocument();
       });
     });
@@ -186,6 +186,36 @@ describe('TodoTable', () => {
 
       await waitFor(() => {
         expect(screen.getByText('Actions')).toBeInTheDocument();
+      });
+    });
+
+    it('should render status column first when included', async () => {
+      vi.mocked(useTodosByWeek).mockReturnValue({
+        data: [
+          createTestTodo({
+            _id: '2025-01-13T10:00:00.000Z',
+            title: 'Test',
+            context: 'work',
+            due: '2025-01-13T10:00:00.000Z',
+          }),
+        ],
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof useTodosByWeek>);
+
+      renderWithPouchDb(
+        <TodoTable {...defaultProps} selectedColumns={['title', 'due', 'status']} />,
+        { testDb: testDb.contextValue },
+      );
+
+      await waitFor(() => {
+        const headers = screen.getAllByRole('columnheader');
+        // First column should be status (empty header), then title, due, actions
+        expect(headers[0].textContent).toBe('');
+        expect(headers[1].textContent).toBe('Title');
+        expect(headers[2].textContent).toBe('Due Date');
+        expect(headers[3].textContent).toBe('Actions');
       });
     });
   });

--- a/packages/web-client/src/components/todo_table.tsx
+++ b/packages/web-client/src/components/todo_table.tsx
@@ -46,13 +46,22 @@ const getColumnWidthClass = (columnId: string): string => {
     due: 'w-32',
     tags: 'w-48',
     timeTracked: 'w-28',
-    status: 'w-20',
+    status: 'w-10',
     completed: 'w-40',
     repeat: 'w-24',
     link: 'w-20',
     description: 'max-w-md',
   };
   return widths[columnId] || '';
+};
+
+const reorderColumnsWithStatusFirst = (columns: string[]): string[] => {
+  const hasStatus = columns.includes('status');
+  if (!hasStatus) {
+    return columns;
+  }
+  const otherColumns = columns.filter((col) => col !== 'status');
+  return ['status', ...otherColumns];
 };
 
 interface TodoTableProps {
@@ -270,14 +279,16 @@ const TodoRow: FC<TodoRowProps> = ({
     }
   };
 
+  const orderedColumns = reorderColumnsWithStatusFirst(selectedColumns);
+
   return (
     <>
       <tr className="border-b border-gray-200 hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700">
-        {selectedColumns.map((columnId) => (
+        {orderedColumns.map((columnId) => (
           <Fragment key={columnId}>{renderCell(columnId)}</Fragment>
         ))}
         <td className="w-24 px-2 py-1">
-          <div className="flex items-center gap-0.5">
+          <div className="flex items-center justify-end gap-0.5">
             {(!timeTrackingActive || thisButtonTimeTrackingActive) && (
               <button
                 className="rounded p-0.5 text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-600"
@@ -465,13 +476,13 @@ export const TodoTable: FC<TodoTableProps> = ({
       due: 'Due Date',
       tags: 'Tags',
       timeTracked: 'Time Tracked',
-      status: 'Status',
+      status: '',
       completed: 'Completed',
       repeat: 'Repeat',
       link: 'Link',
       description: 'Description',
     };
-    return labels[columnId] || columnId;
+    return columnId in labels ? labels[columnId] : columnId;
   };
 
   const handleUpdate = () => {
@@ -504,7 +515,7 @@ export const TodoTable: FC<TodoTableProps> = ({
               <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
                 <thead className="bg-gray-50 dark:bg-gray-700">
                   <tr>
-                    {selectedColumns.map((columnId) => (
+                    {reorderColumnsWithStatusFirst(selectedColumns).map((columnId) => (
                       <th
                         className={`px-2 py-1 text-left text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400 ${getColumnWidthClass(columnId)}`}
                         key={columnId}
@@ -514,7 +525,7 @@ export const TodoTable: FC<TodoTableProps> = ({
                       </th>
                     ))}
                     <th
-                      className="w-24 px-2 py-1 text-left text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400"
+                      className="w-24 px-2 py-1 text-right text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400"
                       scope="col"
                     >
                       Actions

--- a/packages/web-client/src/hooks/use_view_preferences.test.ts
+++ b/packages/web-client/src/hooks/use_view_preferences.test.ts
@@ -28,7 +28,7 @@ describe('useViewPreferences Hook', () => {
     const { result } = renderHook(() => useViewPreferences());
 
     expect(result.current.viewMode).toBe('kanban');
-    expect(result.current.tableColumns).toEqual(['title', 'due', 'tags', 'timeTracked', 'status']);
+    expect(result.current.tableColumns).toEqual(['status', 'title', 'due', 'tags', 'timeTracked']);
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBe(null);
   });

--- a/packages/web-client/src/hooks/use_view_preferences.ts
+++ b/packages/web-client/src/hooks/use_view_preferences.ts
@@ -4,7 +4,7 @@ import { useProfile } from './use_profile';
 
 export type ViewMode = 'kanban' | 'table';
 
-export const DEFAULT_TABLE_COLUMNS = ['title', 'due', 'tags', 'timeTracked', 'status'];
+export const DEFAULT_TABLE_COLUMNS = ['status', 'title', 'due', 'tags', 'timeTracked'];
 
 export interface ViewPreferences {
   viewMode: ViewMode;

--- a/spec/todos/done/2025-12-19-08-19-42-complete-checkbox-first-column.md
+++ b/spec/todos/done/2025-12-19-08-19-42-complete-checkbox-first-column.md
@@ -1,0 +1,83 @@
+# In the table view we want the complete checkbox to be the first column
+
+**Status:** Done
+**Created:** 2025-12-19-08-19-42
+**Started:** 2025-12-19-14-58-01
+**Agent PID:** 98482
+
+## Description
+
+**What we're building:**
+Move the complete checkbox (status column) to always be the first column in the table view, regardless of where it appears in the user's column selection. The checkbox should be the leftmost column when visible, followed by other selected columns, with the Actions column always last.
+
+**How we'll know it works:**
+
+- Status column appears first in table when included in selectedColumns
+- Other columns appear in their relative order after status
+- Actions column remains last
+- Column picker still allows showing/hiding status column
+- All existing tests pass
+- Visual inspection shows checkbox as first column
+
+## Implementation Plan
+
+- [x] Update `DEFAULT_TABLE_COLUMNS` to have status first (packages/web-client/src/hooks/use_view_preferences.ts:7)
+- [x] Modify column rendering logic in TodoTable to always render status first (packages/web-client/src/components/todo_table.tsx:408-438)
+- [x] Modify column rendering logic in TodoRow to match (packages/web-client/src/components/todo_table.tsx:263-270)
+- [x] Update tests to verify status column is first (packages/web-client/src/components/todo_table.test.tsx)
+- [x] Update status column width to w-10 (narrower, checkbox-sized)
+- [x] Remove status column header text (empty string)
+- [x] Right-align Actions column header and content
+- [x] Update use_view_preferences test to match new default order
+- [x] Automated test: Run `pnpm test:unit todo_table`
+- [x] Automated test: Run `pnpm lint` and `pnpm lint:format`
+- [x] User test: Start dev server, view table mode, verify checkbox is first column
+- [x] User test: Toggle status column off/on via column picker, verify behavior
+- [x] User test: Change column selection, verify status stays first when enabled
+
+## Review
+
+**Self-Assessment Findings:**
+
+✅ **Edge Cases Verified:**
+
+- Status column not in selectedColumns: Works correctly, no reordering occurs
+- Status column is the only column: Works correctly, renders as only column
+- Empty selectedColumns: Cannot happen due to column picker's "at least one column" constraint
+- User toggles status on/off: Works correctly, reordering happens at render time
+
+✅ **Performance:**
+
+- `reorderColumnsWithStatusFirst()` is lightweight (filter + spread operation)
+- Called on each render but negligible performance impact
+
+✅ **Code Quality:**
+
+- Helper function is pure and testable
+- Separation of concerns: user preferences stored as-is, reordering only for display
+- Consistent with existing patterns in the codebase
+
+✅ **Accessibility:**
+
+- Empty header for status column is semantically correct (checkbox is self-explanatory)
+- Right-aligned actions column is a common pattern and accessible
+- All interactive elements remain keyboard accessible
+
+✅ **Tests:**
+
+- All 422 unit tests pass (2 skipped)
+- New test verifies column ordering logic
+- Existing tests updated to reflect new behavior
+
+**No issues found - ready for completion**
+
+## Notes
+
+**Implementation Details:**
+
+- Created `reorderColumnsWithStatusFirst()` helper function that ensures status column is always rendered first when present in selectedColumns
+- Applied reordering in both table header and row rendering
+- Status column now has no header text (empty string) and narrower width (w-10 instead of w-20)
+- Actions column header and buttons now right-aligned using `text-right` and `justify-end`
+- Updated DEFAULT_TABLE_COLUMNS to ['status', 'title', 'due', 'tags', 'timeTracked']
+- All tests pass including new test verifying column order


### PR DESCRIPTION
Repositions the checkbox column to the leftmost position in the todo table for improved usability. The status indicator now appears before the title column, making it easier to scan and interact with todo items.

This change improves the visual hierarchy and follows common UI patterns where action items (checkboxes) appear on the left.