### PR TITLE
chore: customize changelog to remove thanks messages

### DIFF
--- a/.changeset/changelog-config.js
+++ b/.changeset/changelog-config.js
@@ -1,0 +1,98 @@
+/**
+ * Custom changelog generator based on @changesets/changelog-github
+ * Removes "Thanks @username!" messages while keeping GitHub links
+ */
+import { getInfo, getInfoFromPullRequest } from '@changesets/get-github-info';
+
+/**
+ * Fetches changelog data from GitHub without adding thanks messages
+ */
+const getReleaseLine = async (changeset, type, options) => {
+  if (!options || !options.repo) {
+    throw new Error(
+      'Please provide a repo to this changelog generator like this:\n"changelog": ["./changelog-config.js", { "repo": "org/repo" }]',
+    );
+  }
+
+  let prFromSummary;
+  let commitFromSummary;
+  const usersFromSummary = [];
+
+  const replacedChangelog = changeset.summary
+    .replace(/^\s*(?:pr|pull|pull\s+request):\s*#?(\d+)/im, (_, pr) => {
+      const num = Number(pr);
+      if (!isNaN(num)) prFromSummary = num;
+      return '';
+    })
+    .replace(/^\s*commit:\s*([^\s]+)/im, (_, commit) => {
+      commitFromSummary = commit;
+      return '';
+    })
+    .replace(/^\s*(?:author|user):\s*@?([^\s]+)/gim, (_, user) => {
+      usersFromSummary.push(user);
+      return '';
+    })
+    .trim();
+
+  const [firstLine, ...futureLines] = replacedChangelog.split('\n').map((l) => l.trimEnd());
+
+  const links = await (async () => {
+    if (prFromSummary !== undefined) {
+      let { links } = await getInfoFromPullRequest({
+        repo: options.repo,
+        pull: prFromSummary,
+      });
+      return links;
+    }
+    const commitToFetchFrom = commitFromSummary || changeset.commit;
+    if (commitToFetchFrom) {
+      let { links } = await getInfo({
+        repo: options.repo,
+        commit: commitToFetchFrom,
+      });
+      return links;
+    }
+    return {
+      commit: null,
+      pull: null,
+      user: null,
+    };
+  })();
+
+  const prefix = [
+    links.pull === null ? '' : ` ${links.pull}`,
+    links.commit === null ? '' : ` ${links.commit}`,
+  ].join('');
+
+  // Note: Removed the "Thanks @username!" suffix
+  return `\n\n-${prefix ? `${prefix} -` : ''} ${firstLine}\n${futureLines.map((l) => `  ${l}`).join('\n')}`;
+};
+
+/**
+ * Generates dependency update lines
+ */
+const getDependencyReleaseLine = async (changesets, dependenciesUpdated, options) => {
+  if (!options || !options.repo) {
+    throw new Error(
+      'Please provide a repo to this changelog generator like this:\n"changelog": ["./changelog-config.js", { "repo": "org/repo" }]',
+    );
+  }
+  if (dependenciesUpdated.length === 0) return '';
+
+  const changesetLink = `- Updated dependencies [${changesets
+    .map((cs) => cs.commit)
+    .filter(Boolean)
+    .map((commit) => `[\`${commit}\`](https://github.com/${options.repo}/commit/${commit})`)
+    .join(', ')}]:`;
+
+  const updatedDepenenciesList = dependenciesUpdated.map(
+    (dependency) => `  - ${dependency.name}@${dependency.newVersion}`,
+  );
+
+  return [changesetLink, ...updatedDepenenciesList].join('\n');
+};
+
+export default {
+  getReleaseLine,
+  getDependencyReleaseLine,
+};

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": [
-    "@changesets/changelog-github",
+    "./.changeset/changelog-config.js",
     {
       "repo": "walterra/eddoapp"
     }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.2",
     "@changesets/cli": "^2.27.1",
+    "@changesets/get-github-info": "^0.7.0",
     "@cloudant/couchbackup": "^2.11.12",
     "@commitlint/cli": "^19.0.0",
     "@commitlint/config-conventional": "^20.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.27.1
         version: 2.29.7(@types/node@24.7.2)
+      '@changesets/get-github-info':
+        specifier: ^0.7.0
+        version: 0.7.0
       '@cloudant/couchbackup':
         specifier: ^2.11.12
         version: 2.11.12(@types/tough-cookie@4.0.5)(axios@1.13.2)(extend@3.0.2)(ibm-cloud-sdk-core@5.4.5)(tough-cookie@6.0.0)


### PR DESCRIPTION
Implements custom changelog configuration to remove default thanks messages from Changesets changelog generation.

Changes:
- Adds custom changelog generator configuration
- Updates Changesets config to use custom changelog
- Removes contributor thanks messages from CHANGELOG.md output
- Maintains commit-based changelog entries