### PR TITLE
chore: convert changelog config to commonjs syntax

### DIFF
--- a/.changeset/changelog-config.js
+++ b/.changeset/changelog-config.js
@@ -2,7 +2,7 @@
  * Custom changelog generator based on @changesets/changelog-github
  * Removes "Thanks @username!" messages while keeping GitHub links
  */
-import { getInfo, getInfoFromPullRequest } from '@changesets/get-github-info';
+const { getInfo, getInfoFromPullRequest } = require('@changesets/get-github-info');
 
 /**
  * Fetches changelog data from GitHub without adding thanks messages
@@ -92,7 +92,7 @@ const getDependencyReleaseLine = async (changesets, dependenciesUpdated, options
   return [changesetLink, ...updatedDepenenciesList].join('\n');
 };
 
-export default {
+module.exports = {
   getReleaseLine,
   getDependencyReleaseLine,
 };


### PR DESCRIPTION
Converts the changelog configuration file from ES6 module syntax to CommonJS syntax. Changes import statements to require() and export default to module.exports. This ensures compatibility with Node.js environments that expect CommonJS modules for configuration files.