### PR TITLE
feat: migrate all UI actions to TanStack Query mutations

### DIFF
--- a/.changeset/tanstack-query-mutations.md
+++ b/.changeset/tanstack-query-mutations.md
@@ -1,0 +1,5 @@
+---
+'eddo-app': minor
+---
+
+Migrate all UI actions to TanStack Query mutations for consistent state management

--- a/packages/web-client/src/components/todo_board.test.tsx
+++ b/packages/web-client/src/components/todo_board.test.tsx
@@ -163,7 +163,7 @@ describe('TodoBoard', () => {
         ).toBeInTheDocument();
       });
 
-      // Verify safeFind was called for todos
+      // Verify safeFind was called for todos with limit
       await waitFor(() => {
         expect(testDb.contextValue.safeDb.safeFind).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -173,6 +173,7 @@ describe('TodoBoard', () => {
               $lte: expect.any(String),
             }),
           }),
+          { limit: 10000 },
         );
       });
     });
@@ -207,6 +208,7 @@ describe('TodoBoard', () => {
             version: 'alpha3',
             active: { $exists: true, $ne: {} },
           }),
+          { limit: 10000 },
         );
       });
     });
@@ -236,6 +238,7 @@ describe('TodoBoard', () => {
             version: 'alpha3',
             active: { $exists: true, $ne: {} },
           }),
+          { limit: 10000 },
         );
       });
     });

--- a/packages/web-client/src/hooks/use_activities_by_week.ts
+++ b/packages/web-client/src/hooks/use_activities_by_week.ts
@@ -35,10 +35,14 @@ export function useActivitiesByWeek({
       const endKey = endDate.toISOString();
 
       // Use Mango to find todos that have active entries
-      const todos = await safeDb.safeFind<Todo>({
-        version: 'alpha3',
-        active: { $exists: true, $ne: {} },
-      });
+      // Note: PouchDB defaults to limit=25, so we set a high limit
+      const todos = await safeDb.safeFind<Todo>(
+        {
+          version: 'alpha3',
+          active: { $exists: true, $ne: {} },
+        },
+        { limit: 10000 },
+      );
 
       // Expand active entries into Activity objects and filter by date range
       const activities: Activity[] = [];

--- a/packages/web-client/src/hooks/use_filter_preferences.test.ts
+++ b/packages/web-client/src/hooks/use_filter_preferences.test.ts
@@ -10,6 +10,53 @@ vi.mock('./use_profile', () => ({
 
 import { useProfile } from './use_profile';
 
+/** Creates mock mutations object for useProfile tests */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const createMockMutations = (): any => ({
+  updateProfile: {
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+    mutateAsync: vi.fn(),
+  },
+  changePassword: {
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+    mutateAsync: vi.fn(),
+  },
+  linkTelegram: {
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+    mutateAsync: vi.fn(),
+  },
+  unlinkTelegram: {
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+    mutateAsync: vi.fn(),
+  },
+  preferences: {
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+    mutateAsync: vi.fn(),
+  },
+  githubResync: {
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+    mutateAsync: vi.fn(),
+  },
+});
+
 describe('useFilterPreferences Hook', () => {
   it('returns default values when no profile data', () => {
     vi.mocked(useProfile).mockReturnValue({
@@ -23,6 +70,7 @@ describe('useFilterPreferences Hook', () => {
       unlinkTelegram: vi.fn(),
       updatePreferences: vi.fn(),
       clearError: vi.fn(),
+      mutations: createMockMutations(),
     });
 
     const { result } = renderHook(() => useFilterPreferences());
@@ -66,6 +114,7 @@ describe('useFilterPreferences Hook', () => {
       unlinkTelegram: vi.fn(),
       updatePreferences: vi.fn(),
       clearError: vi.fn(),
+      mutations: createMockMutations(),
     });
 
     const { result } = renderHook(() => useFilterPreferences());
@@ -91,6 +140,7 @@ describe('useFilterPreferences Hook', () => {
       unlinkTelegram: vi.fn(),
       updatePreferences,
       clearError: vi.fn(),
+      mutations: createMockMutations(),
     });
 
     const { result } = renderHook(() => useFilterPreferences());
@@ -117,6 +167,7 @@ describe('useFilterPreferences Hook', () => {
       unlinkTelegram: vi.fn(),
       updatePreferences,
       clearError: vi.fn(),
+      mutations: createMockMutations(),
     });
 
     const { result } = renderHook(() => useFilterPreferences());
@@ -143,6 +194,7 @@ describe('useFilterPreferences Hook', () => {
       unlinkTelegram: vi.fn(),
       updatePreferences,
       clearError: vi.fn(),
+      mutations: createMockMutations(),
     });
 
     const { result } = renderHook(() => useFilterPreferences());
@@ -168,6 +220,7 @@ describe('useFilterPreferences Hook', () => {
       unlinkTelegram: vi.fn(),
       updatePreferences,
       clearError: vi.fn(),
+      mutations: createMockMutations(),
     });
 
     const { result } = renderHook(() => useFilterPreferences());
@@ -194,6 +247,7 @@ describe('useFilterPreferences Hook', () => {
       unlinkTelegram: vi.fn(),
       updatePreferences,
       clearError: vi.fn(),
+      mutations: createMockMutations(),
     });
 
     const { result } = renderHook(() => useFilterPreferences());
@@ -220,6 +274,7 @@ describe('useFilterPreferences Hook', () => {
       unlinkTelegram: vi.fn(),
       updatePreferences: vi.fn(),
       clearError: vi.fn(),
+      mutations: createMockMutations(),
     });
 
     const { result } = renderHook(() => useFilterPreferences());
@@ -239,6 +294,7 @@ describe('useFilterPreferences Hook', () => {
       unlinkTelegram: vi.fn(),
       updatePreferences: vi.fn(),
       clearError: vi.fn(),
+      mutations: createMockMutations(),
     });
 
     const { result } = renderHook(() => useFilterPreferences());
@@ -271,6 +327,7 @@ describe('useFilterPreferences Hook', () => {
       unlinkTelegram: vi.fn(),
       updatePreferences: vi.fn(),
       clearError: vi.fn(),
+      mutations: createMockMutations(),
     });
 
     const { result } = renderHook(() => useFilterPreferences());

--- a/packages/web-client/src/hooks/use_time_tracking_active.test.ts
+++ b/packages/web-client/src/hooks/use_time_tracking_active.test.ts
@@ -122,10 +122,13 @@ describe('useTimeTrackingActive', () => {
     renderHook(() => useTimeTrackingActive(), { wrapper });
 
     await waitFor(() =>
-      expect(mockSafeDb.safeFind).toHaveBeenCalledWith({
-        version: 'alpha3',
-        active: { $exists: true, $ne: {} },
-      }),
+      expect(mockSafeDb.safeFind).toHaveBeenCalledWith(
+        {
+          version: 'alpha3',
+          active: { $exists: true, $ne: {} },
+        },
+        { limit: 10000 },
+      ),
     );
   });
 

--- a/packages/web-client/src/hooks/use_time_tracking_active.ts
+++ b/packages/web-client/src/hooks/use_time_tracking_active.ts
@@ -25,10 +25,14 @@ export function useTimeTrackingActive({ enabled = true }: UseTimeTrackingActiveP
 
       // Use Mango to find todos that have active entries
       // Then filter client-side for those with null end time (currently tracking)
-      const todos = await safeDb.safeFind<Todo>({
-        version: 'alpha3',
-        active: { $exists: true, $ne: {} },
-      });
+      // Note: PouchDB defaults to limit=25, so we set a high limit
+      const todos = await safeDb.safeFind<Todo>(
+        {
+          version: 'alpha3',
+          active: { $exists: true, $ne: {} },
+        },
+        { limit: 10000 },
+      );
 
       // Filter for todos with active time tracking (any entry with null end time)
       const ids = todos

--- a/packages/web-client/src/hooks/use_todos_by_week.ts
+++ b/packages/web-client/src/hooks/use_todos_by_week.ts
@@ -27,13 +27,17 @@ export function useTodosByWeek({ startDate, endDate, enabled = true }: UseTodosB
       const timerId = `fetchTodos-${Date.now()}`;
       console.time(timerId);
       // Use Mango find (faster than MapReduce views in PouchDB)
-      const todos = await safeDb.safeFind<Todo>({
-        version: 'alpha3',
-        due: {
-          $gte: startDate.toISOString(),
-          $lte: endDate.toISOString(),
+      // Note: PouchDB defaults to limit=25, so we set a high limit
+      const todos = await safeDb.safeFind<Todo>(
+        {
+          version: 'alpha3',
+          due: {
+            $gte: startDate.toISOString(),
+            $lte: endDate.toISOString(),
+          },
         },
-      });
+        { limit: 10000 },
+      );
       console.timeEnd(timerId);
       return todos;
     },

--- a/packages/web-client/src/hooks/use_view_preferences.test.ts
+++ b/packages/web-client/src/hooks/use_view_preferences.test.ts
@@ -10,6 +10,53 @@ vi.mock('./use_profile', () => ({
 
 import { useProfile } from './use_profile';
 
+/** Creates mock mutations object for useProfile tests */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const createMockMutations = (): any => ({
+  updateProfile: {
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+    mutateAsync: vi.fn(),
+  },
+  changePassword: {
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+    mutateAsync: vi.fn(),
+  },
+  linkTelegram: {
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+    mutateAsync: vi.fn(),
+  },
+  unlinkTelegram: {
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+    mutateAsync: vi.fn(),
+  },
+  preferences: {
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+    mutateAsync: vi.fn(),
+  },
+  githubResync: {
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+    mutateAsync: vi.fn(),
+  },
+});
+
 describe('useViewPreferences Hook', () => {
   it('returns default values when no profile data', () => {
     vi.mocked(useProfile).mockReturnValue({
@@ -23,6 +70,7 @@ describe('useViewPreferences Hook', () => {
       unlinkTelegram: vi.fn(),
       updatePreferences: vi.fn(),
       clearError: vi.fn(),
+      mutations: createMockMutations(),
     });
 
     const { result } = renderHook(() => useViewPreferences());
@@ -59,6 +107,7 @@ describe('useViewPreferences Hook', () => {
       unlinkTelegram: vi.fn(),
       updatePreferences: vi.fn(),
       clearError: vi.fn(),
+      mutations: createMockMutations(),
     });
 
     const { result } = renderHook(() => useViewPreferences());
@@ -81,6 +130,7 @@ describe('useViewPreferences Hook', () => {
       unlinkTelegram: vi.fn(),
       updatePreferences,
       clearError: vi.fn(),
+      mutations: createMockMutations(),
     });
 
     const { result } = renderHook(() => useViewPreferences());
@@ -106,6 +156,7 @@ describe('useViewPreferences Hook', () => {
       unlinkTelegram: vi.fn(),
       updatePreferences,
       clearError: vi.fn(),
+      mutations: createMockMutations(),
     });
 
     const { result } = renderHook(() => useViewPreferences());
@@ -130,6 +181,7 @@ describe('useViewPreferences Hook', () => {
       unlinkTelegram: vi.fn(),
       updatePreferences: vi.fn(),
       clearError: vi.fn(),
+      mutations: createMockMutations(),
     });
 
     const { result } = renderHook(() => useViewPreferences());
@@ -149,6 +201,7 @@ describe('useViewPreferences Hook', () => {
       unlinkTelegram: vi.fn(),
       updatePreferences: vi.fn(),
       clearError: vi.fn(),
+      mutations: createMockMutations(),
     });
 
     const { result } = renderHook(() => useViewPreferences());

--- a/spec/todo.md
+++ b/spec/todo.md
@@ -1,4 +1,4 @@
-- all ui actions should make use of tanstack query mutations
+- we updated pouchdb/couchdb views recently and switched some queries to mango. this was done to improve UI primarily. check and fix if the mcp-server queries and db setup/views/indices are still in line with this.
 
 - use knip to identify dead code we can clean up
 

--- a/spec/todos/done/2025-12-23-11-45-59-tanstack-query-mutations.md
+++ b/spec/todos/done/2025-12-23-11-45-59-tanstack-query-mutations.md
@@ -1,0 +1,81 @@
+# All UI actions should use TanStack Query mutations
+
+**Status:** Done
+**Started:** 2025-12-23-11-47
+**GitHub Issue:** https://github.com/walterra/eddoapp/issues/294
+**Created:** 2025-12-23-11-45-59
+**Agent PID:** 37321
+
+## Description
+
+Migrate all direct PouchDB/API calls in UI components to use TanStack Query mutations for consistent state management, optimistic updates, and error handling.
+
+**Success Criteria:**
+
+1. All UI data mutations go through TanStack Query mutations
+2. Consistent loading/error states via mutation `isPending`/`isError`
+3. Optimistic updates where appropriate
+4. Existing tests pass with updated mocks
+
+## Implementation Plan
+
+### Phase 1: Todo Mutations (add_todo.tsx, todo_edit_modal.tsx)
+
+- [x] Create `useCreateTodoMutation` in `use_todo_mutations.ts` for adding todos
+- [x] Create `useDeleteTodoMutation` in `use_todo_mutations.ts` for deleting todos
+- [x] Create `useSaveTodoMutation` in `use_todo_mutations.ts` for editing todos
+- [x] Migrate `add_todo.tsx` to use `useCreateTodoMutation`
+- [x] Migrate `todo_edit_modal.tsx` to use `useSaveTodoMutation` and `useDeleteTodoMutation`
+- [x] Update component tests for profile mock changes
+
+### Phase 2: Profile Mutations (use_profile.ts)
+
+- [x] Create `useUpdateProfileMutation` in `use_profile.ts`
+- [x] Create `useChangePasswordMutation` in `use_profile.ts`
+- [x] Create `useLinkTelegramMutation` in `use_profile.ts`
+- [x] Create `useUnlinkTelegramMutation` in `use_profile.ts`
+- [x] Create `useGithubResyncMutation` in `use_profile.ts`
+- [x] Update return interface to expose mutation states
+- [x] Update `user_profile.tsx` to use mutation loading/error states
+
+### Phase 3: Verification
+
+- [x] Run `pnpm lint` - passes (only pre-existing warnings)
+- [x] Run `pnpm tsc:check` - passes
+- [x] Run `pnpm test` - passes (462 passed)
+- [x] User test: Add a todo, verify it appears immediately
+- [x] User test: Edit a todo, verify changes appear immediately
+- [x] User test: Delete a todo, verify it disappears immediately
+- [x] User test: Toggle completion, verify state updates immediately
+
+## Review
+
+- [x] Fixed cache issue: todos moving between days now correctly update views
+- [x] Fixed PouchDB limit bug: safeFind queries now use limit=10000 to fetch all results
+
+## Notes
+
+**Changes Made:**
+
+1. **use_todo_mutations.ts**:
+   - Added `useCreateTodoMutation` - invalidates queries on success
+   - Added `useDeleteTodoMutation` - optimistic removal from cache
+   - Added `useSaveTodoMutation` - direct save without optimistic updates, invalidates all queries on success
+
+2. **add_todo.tsx**: Migrated from direct `safeDb.safePut()` to `useCreateTodoMutation`
+
+3. **todo_edit_modal.tsx**: Migrated from direct PouchDB calls to mutations
+
+4. **use_profile.ts**: All API calls now use mutations, exposed via `mutations` object
+
+5. **user_profile.tsx**: `handleForceResync` now uses `mutations.githubResync.mutateAsync()`
+
+6. **Critical Bug Fix - PouchDB limit**:
+   - PouchDB's `find()` defaults to limit=25
+   - With 5451 documents, only first 25 were returned
+   - Fixed by adding `{ limit: 10000 }` to all `safeFind` calls in:
+     - `use_todos_by_week.ts`
+     - `use_activities_by_week.ts`
+     - `use_time_tracking_active.ts`
+
+7. **Cache invalidation fix**: `useSaveTodoMutation` now invalidates all todo queries on success to handle due date changes correctly


### PR DESCRIPTION
## Summary

Migrate all direct PouchDB/API calls in UI components to use TanStack Query mutations for consistent state management, optimistic updates, and error handling.

## Changes

- Add `useCreateTodoMutation`, `useDeleteTodoMutation`, `useSaveTodoMutation` hooks
- Migrate `add_todo.tsx` to use `useCreateTodoMutation`
- Migrate `todo_edit_modal.tsx` to use `useSaveTodoMutation` and `useDeleteTodoMutation`
- Convert all `use_profile.ts` API calls to mutations with exposed state via `mutations` object
- Update `user_profile.tsx` to use `mutations.githubResync` for GitHub resync

## Benefits

- Consistent loading/error states via `isPending`/`isError`
- Proper cache invalidation when todos are modified
- Centralized mutation logic
- Easier testing with mutation mocks

Closes #294