### PR TITLE
fix: MCP server missing database indexes (externalId-index, tags-index)

### DIFF
--- a/.changeset/mcp-server-indexes-alignment.md
+++ b/.changeset/mcp-server-indexes-alignment.md
@@ -1,0 +1,5 @@
+---
+'eddo-app': patch
+---
+
+Fix MCP server missing database indexes (externalId-index, tags-index)

--- a/packages/mcp_server/src/integration-tests/setup/database-setup.ts
+++ b/packages/mcp_server/src/integration-tests/setup/database-setup.ts
@@ -4,7 +4,7 @@
  * Separated from MCP server for better architecture and test isolation
  */
 import { getCouchDbConfig, validateEnv } from '@eddo/core-server';
-import { DESIGN_DOCS, type DesignDocument } from '@eddo/core-shared';
+import { DESIGN_DOCS, type DesignDocument, REQUIRED_INDEXES } from '@eddo/core-shared';
 import nano from 'nano';
 
 export class DatabaseSetup {
@@ -92,56 +92,12 @@ export class DatabaseSetup {
 
   /**
    * Create CouchDB indexes for efficient querying
+   * Uses shared REQUIRED_INDEXES from @eddo/core-shared for consistency
    */
   async createIndexes(): Promise<void> {
     console.log(`🔍 Creating indexes for: ${this.dbName}`);
 
-    // Try a very simple index first to test if indexing works at all
-    const simpleIndex = {
-      index: { fields: ['due'] },
-      name: 'simple-due-index',
-      type: 'json' as const,
-    };
-
-    try {
-      await this.db.createIndex(simpleIndex);
-      console.log(`✅ Created simple index: ${simpleIndex.name}`);
-    } catch (error) {
-      console.error(`❌ Failed to create simple index:`, error);
-    }
-
-    const indexes: Array<{
-      index: { fields: string[] };
-      name: string;
-      type: 'json' | 'text';
-    }> = [
-      // Primary index for basic queries with sort
-      {
-        index: { fields: ['version', 'due'] },
-        name: 'version-due-index',
-        type: 'json',
-      },
-      // Index for context filtering with sort
-      {
-        index: { fields: ['version', 'context', 'due'] },
-        name: 'version-context-due-index',
-        type: 'json',
-      },
-      // Index for completion filtering with sort
-      {
-        index: { fields: ['version', 'completed', 'due'] },
-        name: 'version-completed-due-index',
-        type: 'json',
-      },
-      // Index for both context and completion filtering with sort
-      {
-        index: { fields: ['version', 'context', 'completed', 'due'] },
-        name: 'version-context-completed-due-index',
-        type: 'json',
-      },
-    ];
-
-    for (const indexDef of indexes) {
+    for (const indexDef of REQUIRED_INDEXES) {
       await this.createSingleIndexWithRetry(indexDef);
     }
 

--- a/spec/todo.md
+++ b/spec/todo.md
@@ -1,5 +1,3 @@
-- we updated pouchdb/couchdb views recently and switched some queries to mango. this was done to improve UI primarily. check and fix if the mcp-server queries and db setup/views/indices are still in line with this.
-
 - use knip to identify dead code we can clean up
 
 - **Investigate infinite \_all_docs loop in web-api dev server**: Web-api process gets stuck requesting `_all_docs?include_docs=true` continuously (10-15 req/sec), causing CouchDB to consume 900%+ CPU. Happened 2025-12-18 with process 7639 making 172+ requests in 200 log lines. Possible causes: PouchDB replication/sync issue, React infinite re-render triggering database queries, or changes feed listener gone wild. Add monitoring/detection and fix root cause in web-client or web-api code.

--- a/spec/todos/done/2025-12-23-17-58-50-mcp-server-queries-alignment.md
+++ b/spec/todos/done/2025-12-23-17-58-50-mcp-server-queries-alignment.md
@@ -1,0 +1,74 @@
+# MCP Server queries/views alignment
+
+**Status:** Done
+**Created:** 2025-12-23-17-58-50
+**Started:** 2025-12-23-18-02-51
+**GitHub Issue:** https://github.com/walterra/eddoapp/issues/299
+**Agent PID:** 37321
+
+## Description
+
+Align MCP server database setup with the shared `REQUIRED_INDEXES` from `@eddo/core-shared`. The MCP server's `DatabaseSetup.createIndexes()` method is missing two indexes that are defined in the shared module and used by the application:
+
+1. `externalId-index` - Used for GitHub issue sync deduplication
+2. `tags-index` - Used for tag-based queries (e.g., fetching user memories)
+
+**Success criteria:**
+
+- MCP server's `DatabaseSetup` uses `REQUIRED_INDEXES` from `@eddo/core-shared` (DRY principle)
+- All indexes are created consistently across web-client, web-api, and mcp-server
+- Existing integration tests pass
+
+## Implementation Plan
+
+- [x] Update `packages/mcp_server/src/integration-tests/setup/database-setup.ts` to use `REQUIRED_INDEXES` from `@eddo/core-shared` instead of duplicating index definitions
+- [x] Remove duplicated index definitions from MCP server database-setup
+- [x] Verify MCP server integration tests pass (requires running CouchDB)
+- [x] Run unit test suite (462 tests pass)
+- [x] TypeScript check passes
+- [x] Lint passes (no errors)
+
+## Review
+
+- [x] Confirm no duplicate code remains
+- [x] Verify all packages use the same shared definitions
+- [x] Code change is minimal and focused (removed ~45 lines of duplicated code)
+
+## Notes
+
+### Current State Analysis
+
+**Shared definitions in `core-shared/src/api/database-structures.ts`:**
+
+- `DESIGN_DOCS`: 4 design documents (todos_by_active, todos_by_due_date, todos_by_time_tracking_active, tags)
+- `REQUIRED_INDEXES`: 6 indexes:
+  1. `version-due-index`
+  2. `version-context-due-index`
+  3. `version-completed-due-index`
+  4. `version-context-completed-due-index`
+  5. `externalId-index` ← MISSING from MCP server
+  6. `tags-index` ← MISSING from MCP server
+
+**MCP server `database-setup.ts` issues:**
+
+- Already imports `DESIGN_DOCS` from `@eddo/core-shared` ✓
+- Creates its own hardcoded index list with only 4 indexes (missing externalId-index and tags-index)
+- Also creates a redundant `simple-due-index` not in the shared definitions
+
+**Web-api `setup-user-db.ts`:**
+
+- Uses both `DESIGN_DOCS` and `REQUIRED_INDEXES` from `@eddo/core-shared` ✓
+
+**Web-client `database_setup.ts`:**
+
+- Uses both `DESIGN_DOCS` and `REQUIRED_INDEXES` from `@eddo/core-shared` ✓
+
+### Query Usage in MCP Server
+
+MCP server uses:
+
+1. **Mango queries** with `use_index` for `listTodos` (uses version-\* indexes)
+2. **MapReduce view** for `getActiveTimeTracking` (uses `todos_by_time_tracking_active` design doc)
+3. **MapReduce view** for tag stats in `getServerInfo` (uses `tags` design doc)
+4. **Mango query** for memories in `getServerInfo` with `use_index: 'tags-index'` ← **Will fail if index missing!**
+5. **`externalId` filter** in `listTodos` ← **Needs externalId-index for performance**


### PR DESCRIPTION
## Summary

Update MCP server's `DatabaseSetup.createIndexes()` to use `REQUIRED_INDEXES` from `@eddo/core-shared` instead of duplicating index definitions.

## Changes

- Import `REQUIRED_INDEXES` from `@eddo/core-shared`
- Remove ~45 lines of duplicated index definitions
- MCP server now creates all 6 indexes consistently with web-client and web-api

## Missing Indexes Added

- `externalId-index` - Required for GitHub issue sync deduplication
- `tags-index` - Required for tag-based queries (e.g., fetching user memories)

Closes #299