### PR TITLE
fix: resolve high severity qs DoS vulnerability via pnpm override

### DIFF
--- a/.changeset/fix-qs-vulnerability.md
+++ b/.changeset/fix-qs-vulnerability.md
@@ -1,0 +1,5 @@
+---
+'eddo-app': patch
+---
+
+Fix high severity qs DoS vulnerability via pnpm override

--- a/package.json
+++ b/package.json
@@ -163,7 +163,8 @@
   ],
   "pnpm": {
     "overrides": {
-      "jws": ">=4.0.0"
+      "jws": ">=4.0.0",
+      "qs": ">=6.14.1"
     },
     "onlyBuiltDependencies": [
       "@swc/core",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   jws: '>=4.0.0'
+  qs: '>=6.14.1'
 
 importers:
 
@@ -5856,8 +5857,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+  qs@6.14.1:
+    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
     engines: {node: '>=0.6'}
 
   querystringify@2.2.0:
@@ -9654,7 +9655,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.1
       on-finished: 2.4.1
-      qs: 6.14.0
+      qs: 6.14.1
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -10728,7 +10729,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.0
+      qs: 6.14.1
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -10804,7 +10805,7 @@ snapshots:
       strict-event-emitter-types: 2.0.0
       undici: 7.16.0
       uri-templates: 0.2.0
-      xsschema: 0.4.0-beta.5(zod-to-json-schema@3.25.0(zod@4.2.1))(zod@4.2.1)
+      xsschema: 0.4.0-beta.5(zod-to-json-schema@3.25.0(zod@3.25.76))(zod@4.2.1)
       yargs: 18.0.0
       zod: 4.2.1
       zod-to-json-schema: 3.25.0(zod@4.2.1)
@@ -12124,7 +12125,7 @@ snapshots:
     dependencies:
       axios: 1.13.2(debug@4.4.3)
       node-abort-controller: 3.1.1
-      qs: 6.14.0
+      qs: 6.14.1
     transitivePeerDependencies:
       - debug
 
@@ -12723,7 +12724,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.14.0:
+  qs@6.14.1:
     dependencies:
       side-channel: 1.1.0
 
@@ -14013,7 +14014,7 @@ snapshots:
       zod: 3.25.76
       zod-to-json-schema: 3.24.6(zod@3.25.76)
 
-  xsschema@0.4.0-beta.5(zod-to-json-schema@3.25.0(zod@4.2.1))(zod@4.2.1):
+  xsschema@0.4.0-beta.5(zod-to-json-schema@3.25.0(zod@3.25.76))(zod@4.2.1):
     optionalDependencies:
       zod: 4.2.1
       zod-to-json-schema: 3.25.0(zod@4.2.1)


### PR DESCRIPTION
Adds pnpm override for `qs` package to resolve CVE-2025-33128 (GHSA-hphj-897m-v97j), a high severity Denial of Service vulnerability.

## Changes

- Add `qs: >=6.14.1` to pnpm overrides in `package.json`
- Update `pnpm-lock.yaml` to use patched version

## Security

This vulnerability allows attackers to cause uncontrolled resource consumption via specially crafted query strings with deeply nested objects. The override ensures all transitive dependencies use the patched version.