### PR TITLE
feat: add remember me checkbox to login page

### DIFF
--- a/.changeset/remember-me-login.md
+++ b/.changeset/remember-me-login.md
@@ -1,0 +1,5 @@
+---
+'eddo-app': minor
+---
+
+Add "Remember me" checkbox to login page for persistent authentication sessions

--- a/packages/web-api/src/routes/auth.test.ts
+++ b/packages/web-api/src/routes/auth.test.ts
@@ -1,18 +1,33 @@
 import { Hono } from 'hono';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { authRoutes } from './auth';
-
 // Mock the config module
 vi.mock('../config', () => ({
   config: {
     jwtSecret: 'test-secret-key-at-least-32-characters-long-for-testing',
     couchdb: {
+      url: 'http://admin:password@localhost:5984',
       username: 'admin',
       password: 'password',
     },
   },
 }));
+
+// Mock core-server to avoid environment validation
+vi.mock('@eddo/core-server', () => ({
+  createEnv: () => ({
+    COUCHDB_URL: 'http://admin:password@localhost:5984',
+  }),
+  createUserRegistry: () => ({
+    findByUsername: vi.fn().mockResolvedValue(null),
+    findByEmail: vi.fn().mockResolvedValue(null),
+    findByTelegramId: vi.fn().mockResolvedValue(null),
+    create: vi.fn(),
+    update: vi.fn(),
+  }),
+}));
+
+import { authRoutes } from './auth';
 
 describe('Authentication Routes', () => {
   let app: Hono;
@@ -22,7 +37,7 @@ describe('Authentication Routes', () => {
     app.route('/auth', authRoutes);
   });
 
-  it('should login with valid credentials', async () => {
+  it('should login with valid credentials (short session by default)', async () => {
     const response = await app.request('/auth/login', {
       method: 'POST',
       headers: {
@@ -38,7 +53,45 @@ describe('Authentication Routes', () => {
     const data = await response.json();
     expect(data).toHaveProperty('token');
     expect(data).toHaveProperty('username', 'demo');
-    expect(data).toHaveProperty('expiresIn', '24h');
+    expect(data).toHaveProperty('expiresIn', '1h');
+  });
+
+  it('should login with rememberMe=false for short session', async () => {
+    const response = await app.request('/auth/login', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        username: 'demo',
+        password: 'password',
+        rememberMe: false,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toHaveProperty('token');
+    expect(data).toHaveProperty('expiresIn', '1h');
+  });
+
+  it('should login with rememberMe=true for long session', async () => {
+    const response = await app.request('/auth/login', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        username: 'demo',
+        password: 'password',
+        rememberMe: true,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toHaveProperty('token');
+    expect(data).toHaveProperty('expiresIn', '30d');
   });
 
   it('should reject invalid credentials', async () => {

--- a/packages/web-client/src/components/login.test.tsx
+++ b/packages/web-client/src/components/login.test.tsx
@@ -1,0 +1,122 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Login } from './login';
+
+describe('Login Component', () => {
+  const mockOnLogin = vi.fn();
+  const mockOnGoToRegister = vi.fn();
+
+  const defaultProps = {
+    onLogin: mockOnLogin,
+    isAuthenticating: false,
+    onGoToRegister: mockOnGoToRegister,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOnLogin.mockResolvedValue(true);
+  });
+
+  it('renders login form with all fields', () => {
+    render(<Login {...defaultProps} />);
+
+    expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/remember me/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+  });
+
+  it('renders remember me checkbox unchecked by default', () => {
+    render(<Login {...defaultProps} />);
+
+    const checkbox = screen.getByLabelText(/remember me/i);
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('allows toggling remember me checkbox', () => {
+    render(<Login {...defaultProps} />);
+
+    const checkbox = screen.getByLabelText(/remember me/i);
+    expect(checkbox).not.toBeChecked();
+
+    fireEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+
+    fireEvent.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('calls onLogin with rememberMe=false when checkbox is unchecked', async () => {
+    render(<Login {...defaultProps} />);
+
+    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'testuser' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'password123' } });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockOnLogin).toHaveBeenCalledWith('testuser', 'password123', false);
+    });
+  });
+
+  it('calls onLogin with rememberMe=true when checkbox is checked', async () => {
+    render(<Login {...defaultProps} />);
+
+    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'testuser' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'password123' } });
+    fireEvent.click(screen.getByLabelText(/remember me/i));
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockOnLogin).toHaveBeenCalledWith('testuser', 'password123', true);
+    });
+  });
+
+  it('disables all inputs while authenticating', () => {
+    render(<Login {...defaultProps} isAuthenticating={true} />);
+
+    expect(screen.getByLabelText(/username/i)).toBeDisabled();
+    expect(screen.getByLabelText(/password/i)).toBeDisabled();
+    expect(screen.getByLabelText(/remember me/i)).toBeDisabled();
+    expect(screen.getByRole('button', { name: /signing in/i })).toBeDisabled();
+  });
+
+  it('shows error when login fails', async () => {
+    mockOnLogin.mockResolvedValue(false);
+    render(<Login {...defaultProps} />);
+
+    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'testuser' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'wrongpassword' } });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid credentials')).toBeInTheDocument();
+    });
+  });
+
+  it('does not call onLogin when form is submitted with empty fields', async () => {
+    render(<Login {...defaultProps} />);
+
+    // Form has 'required' attributes, so submission should be blocked
+    // In jsdom, we test that onLogin is not called
+    const form = screen.getByRole('button', { name: /sign in/i }).closest('form');
+    expect(form).toBeInTheDocument();
+
+    // Clicking submit with empty required fields should not call onLogin
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    // Give time for any async operations
+    await waitFor(() => {
+      expect(mockOnLogin).not.toHaveBeenCalled();
+    });
+  });
+
+  it('navigates to register when link is clicked', () => {
+    render(<Login {...defaultProps} />);
+
+    fireEvent.click(screen.getByText(/create account/i));
+
+    expect(mockOnGoToRegister).toHaveBeenCalled();
+  });
+});

--- a/packages/web-client/src/components/login.tsx
+++ b/packages/web-client/src/components/login.tsx
@@ -1,8 +1,8 @@
-import { Button, Card, Label, TextInput } from 'flowbite-react';
+import { Button, Card, Checkbox, Label, TextInput } from 'flowbite-react';
 import { useState } from 'react';
 
 interface LoginProps {
-  onLogin: (username: string, password: string) => Promise<boolean>;
+  onLogin: (username: string, password: string, rememberMe: boolean) => Promise<boolean>;
   isAuthenticating: boolean;
   onGoToRegister: () => void;
 }
@@ -10,6 +10,7 @@ interface LoginProps {
 export function Login({ onLogin, isAuthenticating, onGoToRegister }: LoginProps) {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const [rememberMe, setRememberMe] = useState(false);
   const [error, setError] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -21,7 +22,7 @@ export function Login({ onLogin, isAuthenticating, onGoToRegister }: LoginProps)
       return;
     }
 
-    const success = await onLogin(username, password);
+    const success = await onLogin(username, password, rememberMe);
     if (!success) {
       setError('Invalid credentials');
     }
@@ -72,6 +73,16 @@ export function Login({ onLogin, isAuthenticating, onGoToRegister }: LoginProps)
               type="password"
               value={password}
             />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Checkbox
+              checked={rememberMe}
+              disabled={isAuthenticating}
+              id="rememberMe"
+              onChange={(e) => setRememberMe(e.target.checked)}
+            />
+            <Label htmlFor="rememberMe">Remember me</Label>
           </div>
 
           <Button className="w-full" color="blue" disabled={isAuthenticating} type="submit">

--- a/packages/web-client/src/hooks/use_auth.test.tsx
+++ b/packages/web-client/src/hooks/use_auth.test.tsx
@@ -179,6 +179,64 @@ describe('useAuth Hook', () => {
       expect(result.current.isAuthenticated).toBe(false);
     });
 
+    it('passes rememberMe flag to login request', async () => {
+      const mockToken = {
+        token: 'test-token',
+        username: 'testuser',
+        expiresIn: '30d',
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockToken),
+      });
+
+      const { result } = renderHook(() => useAuth(), {
+        wrapper: AuthTestWrapper,
+      });
+
+      await act(async () => {
+        await result.current.authenticate('testuser', 'password', true);
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith('/auth/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ username: 'testuser', password: 'password', rememberMe: true }),
+      });
+    });
+
+    it('defaults rememberMe to false when not provided', async () => {
+      const mockToken = {
+        token: 'test-token',
+        username: 'testuser',
+        expiresIn: '1h',
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockToken),
+      });
+
+      const { result } = renderHook(() => useAuth(), {
+        wrapper: AuthTestWrapper,
+      });
+
+      await act(async () => {
+        await result.current.authenticate('testuser', 'password');
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith('/auth/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ username: 'testuser', password: 'password', rememberMe: false }),
+      });
+    });
+
     it('handles logout', async () => {
       const mockToken = {
         token: 'test-token',

--- a/packages/web-client/src/hooks/use_auth.tsx
+++ b/packages/web-client/src/hooks/use_auth.tsx
@@ -9,7 +9,7 @@ interface AuthToken {
 
 interface AuthContextValue {
   authToken: AuthToken | null;
-  authenticate: (username: string, password: string) => Promise<boolean>;
+  authenticate: (username: string, password: string, rememberMe?: boolean) => Promise<boolean>;
   register: (
     username: string,
     email: string,
@@ -37,7 +37,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [authToken, setAuthToken] = useState<AuthToken | null>(null);
   const [isAuthenticating, setIsAuthenticating] = useState(false);
 
-  const authenticate = async (username: string, password: string): Promise<boolean> => {
+  const authenticate = async (
+    username: string,
+    password: string,
+    rememberMe: boolean = false,
+  ): Promise<boolean> => {
     setIsAuthenticating(true);
     try {
       const response = await fetch('/auth/login', {
@@ -45,7 +49,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ username, password }),
+        body: JSON.stringify({ username, password, rememberMe }),
       });
 
       if (response.ok) {

--- a/spec/todo.md
+++ b/spec/todo.md
@@ -4,7 +4,6 @@ All items are synced with GitHub Issues.
 
 ## Features
 
-- Remember me for login - [#327](https://github.com/walterra/eddoapp/issues/327)
 - Improve briefing prompt to not repeat itself - [#328](https://github.com/walterra/eddoapp/issues/328)
 - Workflow to proceed with read-later items - [#329](https://github.com/walterra/eddoapp/issues/329)
 - Due date quick actions / bulk actions - [#330](https://github.com/walterra/eddoapp/issues/330)

--- a/spec/todos/done/2026-01-01-22-49-34-remember-me-login.md
+++ b/spec/todos/done/2026-01-01-22-49-34-remember-me-login.md
@@ -1,0 +1,53 @@
+# Remember me for login
+
+**Status:** Done
+**Started:** 2026-01-01T22:25:09
+**Created:** 2026-01-01-22-49-34
+**Agent PID:** 7069
+**GitHub Issue:** [#327](https://github.com/walterra/eddoapp/issues/327)
+
+## Description
+
+Add a "Remember me" checkbox to the login page. When checked, authentication persists across browser sessions using longer-lived JWT tokens.
+
+**Current behavior:**
+
+- JWT tokens expire after 24 hours (hardcoded in `packages/web-api/src/routes/auth.ts`)
+- Tokens stored in localStorage persist until expiration
+- No user choice for session duration
+
+**Target behavior:**
+
+- Default (unchecked): Short session (e.g., 1 hour or session-only)
+- Remember me (checked): Long session (e.g., 30 days)
+- Backend accepts `rememberMe` flag and adjusts token expiration accordingly
+
+**Success criteria:**
+
+- Login form shows "Remember me" checkbox
+- Unchecked: Token expires in 1 hour (or cleared on browser close)
+- Checked: Token expires in 30 days
+- Existing tests pass, new tests cover the feature
+
+## Implementation Plan
+
+- [x] Backend: Update `/auth/login` to accept `rememberMe` boolean and adjust token expiration (packages/web-api/src/routes/auth.ts:109-141)
+- [x] Backend: Update `/auth/register` to accept `rememberMe` boolean (packages/web-api/src/routes/auth.ts:43-100)
+- [x] Backend: Add tests for rememberMe parameter (packages/web-api/src/routes/auth.test.ts)
+- [x] Frontend: Add `rememberMe` checkbox to Login component (packages/web-client/src/components/login.tsx)
+- [x] Frontend: Update `useAuth` hook to pass `rememberMe` to authenticate call (packages/web-client/src/hooks/use_auth.tsx)
+- [x] Frontend: Add test for Login component checkbox (packages/web-client/src/components/login.test.tsx - new file created)
+- [x] Automated test: Verify short vs long token expiration (5 backend tests + 2 hook tests + 9 component tests)
+- [x] User test: Login with/without "Remember me" and verify behavior (verified 30d in localStorage)
+
+## Review
+
+- [x] No bugs found - all tests pass
+- [x] Code follows project patterns (functional style, Zod validation, Flowbite components)
+- [x] Lint passes with 0 errors
+
+## Notes
+
+- Token expiration is set via `exp` claim in JWT: `Math.floor(Date.now() / 1000) + 24 * 60 * 60`
+- Both `/auth/login` and `/auth/register` endpoints generate tokens with same 24h expiration
+- Frontend stores token in localStorage regardless of remember me - for short sessions, could use sessionStorage instead


### PR DESCRIPTION
Add a 'Remember me' checkbox on the login page to persist authentication across browser sessions.

## Changes

- Add `rememberMe` parameter to `/auth/login` and `/auth/register` endpoints
- Unchecked (default): 1-hour token expiration
- Checked: 30-day token expiration
- Add Flowbite Checkbox component to login form
- Update `useAuth` hook to pass `rememberMe` flag to API

## Testing

- 5 backend tests for token expiration logic
- 2 hook tests for `rememberMe` parameter passing
- 9 component tests for checkbox UI behavior

Closes #327