### PR TITLE
feat: refactor todo flyout to view-first mode

### DIFF
--- a/packages/core-client/src/index.ts
+++ b/packages/core-client/src/index.ts
@@ -5,9 +5,10 @@ export {
   // Database monitoring
   DatabaseHealthMonitor,
   DatabaseOperationError,
+  // Utils
+  areTodosEqual,
   createDefaultUserPreferences,
   decodeJwtPayload,
-  // Utils
   generateStableKey,
   getActiveDuration,
   getActiveRecordForActivities,

--- a/packages/core-shared/src/index.ts
+++ b/packages/core-shared/src/index.ts
@@ -64,6 +64,7 @@ export {
 } from './api/database-structures';
 
 // Utils
+export { areTodosEqual } from './utils/are_todos_equal';
 export { generateStableKey } from './utils/generate_stable_key';
 export { getActiveDuration } from './utils/get_active_duration';
 export { getActiveRecordForActivities } from './utils/get_active_record_for_activities';

--- a/packages/core-shared/src/utils/are_todos_equal.ts
+++ b/packages/core-shared/src/utils/are_todos_equal.ts
@@ -1,0 +1,18 @@
+/**
+ * Compares two todos for equality, excluding _rev
+ */
+import type { Todo } from '../types/todo.js';
+
+/**
+ * Compares todos excluding _rev to prevent unnecessary re-renders on save.
+ * The _rev field changes on every database update but doesn't represent
+ * a meaningful change to the todo content.
+ * @param prev - Previous todo
+ * @param next - Next todo
+ * @returns True if todos are equal (ignoring _rev)
+ */
+export const areTodosEqual = (prev: Todo, next: Todo): boolean => {
+  const { _rev: _prevRev, ...prevRest } = prev;
+  const { _rev: _nextRev, ...nextRest } = next;
+  return JSON.stringify(prevRest) === JSON.stringify(nextRest);
+};

--- a/packages/web-client/src/components/todo_flyout.tsx
+++ b/packages/web-client/src/components/todo_flyout.tsx
@@ -1,0 +1,228 @@
+/**
+ * Flyout panel for viewing and editing todo items
+ */
+import { type Todo } from '@eddo/core-client';
+import { Button, Drawer, DrawerHeader, DrawerItems } from 'flowbite-react';
+import { type FC } from 'react';
+import { BiEdit, BiShow } from 'react-icons/bi';
+
+import { useTags } from '../hooks/use_tags';
+import { useTodoFlyoutState } from '../hooks/use_todo_flyout_state';
+import { BTN_GHOST, BTN_PRIMARY, TRANSITION } from '../styles/interactive';
+import { ErrorDisplay } from './todo_edit_error';
+import {
+  CompletedField,
+  ContextField,
+  DescriptionField,
+  DueDateField,
+  ExternalIdField,
+  LinkField,
+  RepeatField,
+  TagsField,
+  TimeTrackingField,
+  TitleField,
+  validateTimeTracking,
+} from './todo_edit_fields';
+import { TodoViewFields } from './todo_view_fields';
+
+type FlyoutMode = 'view' | 'edit';
+
+interface TodoFlyoutProps {
+  onClose: () => void;
+  show: boolean;
+  todo: Todo;
+}
+
+interface UnsavedChangesDialogProps {
+  onDiscard: () => void;
+  onKeepEditing: () => void;
+}
+
+const UnsavedChangesDialog: FC<UnsavedChangesDialogProps> = ({ onDiscard, onKeepEditing }) => (
+  <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+    <div className="mx-4 max-w-sm rounded-lg border border-neutral-200 bg-white p-6 shadow-xl dark:border-neutral-700 dark:bg-neutral-800">
+      <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">Unsaved Changes</h3>
+      <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+        You have unsaved changes. Do you want to discard them?
+      </p>
+      <div className="mt-4 flex justify-end gap-3">
+        <button className={BTN_GHOST} onClick={onKeepEditing} type="button">
+          Keep Editing
+        </button>
+        <button
+          className={`${BTN_PRIMARY} bg-red-600 hover:bg-red-700`}
+          onClick={onDiscard}
+          type="button"
+        >
+          Discard
+        </button>
+      </div>
+    </div>
+  </div>
+);
+
+interface ModeToggleProps {
+  mode: FlyoutMode;
+  onToggle: () => void;
+}
+
+const ModeToggle: FC<ModeToggleProps> = ({ mode, onToggle }) => (
+  <button
+    className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium ${TRANSITION} ${
+      mode === 'view'
+        ? 'text-neutral-600 hover:bg-neutral-100 dark:text-neutral-400 dark:hover:bg-neutral-700'
+        : 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300'
+    }`}
+    onClick={onToggle}
+    title={mode === 'view' ? 'Switch to edit mode' : 'Switch to view mode'}
+    type="button"
+  >
+    {mode === 'view' ? (
+      <>
+        <BiEdit size="1.1em" />
+        Edit
+      </>
+    ) : (
+      <>
+        <BiShow size="1.1em" />
+        View
+      </>
+    )}
+  </button>
+);
+
+interface EditFormFieldsProps {
+  todo: Todo;
+  allTags: string[];
+  activeArray: Array<[string, string | null]>;
+  onChange: (updater: (todo: Todo) => Todo) => void;
+}
+
+const EditFormFields: FC<EditFormFieldsProps> = ({ todo, allTags, activeArray, onChange }) => (
+  <div className="flex flex-col gap-6">
+    <TitleField onChange={onChange} todo={todo} />
+    <DescriptionField onChange={onChange} todo={todo} />
+    <ContextField onChange={onChange} todo={todo} />
+    <TagsField allTags={allTags} onChange={onChange} todo={todo} />
+    <DueDateField onChange={onChange} todo={todo} />
+    <LinkField onChange={onChange} todo={todo} />
+    <ExternalIdField onChange={onChange} todo={todo} />
+    <RepeatField onChange={onChange} todo={todo} />
+    <CompletedField onChange={onChange} todo={todo} />
+    <TimeTrackingField activeArray={activeArray} onChange={onChange} todo={todo} />
+  </div>
+);
+
+interface ViewModeActionsProps {
+  onDelete: (e: React.FormEvent<HTMLButtonElement>) => void;
+  isDeleting: boolean;
+}
+
+const ViewModeActions: FC<ViewModeActionsProps> = ({ onDelete, isDeleting }) => (
+  <div className="flex w-full justify-end border-t border-neutral-200 bg-white px-4 py-4 dark:border-neutral-700 dark:bg-neutral-800">
+    <Button color="red" disabled={isDeleting} onClick={onDelete}>
+      {isDeleting ? 'Deleting...' : 'Delete'}
+    </Button>
+  </div>
+);
+
+interface EditModeActionsProps {
+  onSave: (e: React.FormEvent<HTMLButtonElement>) => void;
+  onCancel: () => void;
+  isActiveValid: boolean;
+  isSaving: boolean;
+}
+
+const EditModeActions: FC<EditModeActionsProps> = ({
+  onSave,
+  onCancel,
+  isActiveValid,
+  isSaving,
+}) => (
+  <div className="flex w-full justify-between border-t border-neutral-200 bg-white px-4 py-4 dark:border-neutral-700 dark:bg-neutral-800">
+    <Button color="gray" disabled={isSaving} onClick={onCancel}>
+      Cancel
+    </Button>
+    <Button color="blue" disabled={!isActiveValid || isSaving} onClick={onSave}>
+      {isSaving ? 'Saving...' : 'Save'}
+    </Button>
+  </div>
+);
+
+interface FlyoutContentProps {
+  todo: Todo;
+  state: ReturnType<typeof useTodoFlyoutState>;
+  allTags: string[];
+  activeArray: Array<[string, string | null]>;
+}
+
+const FlyoutContent: FC<FlyoutContentProps> = ({ todo, state, allTags, activeArray }) => (
+  <div className="flex h-full flex-col">
+    <div className="flex-1 overflow-y-auto p-4">
+      {state.error && <ErrorDisplay error={state.error} onClear={state.clearError} />}
+      {state.mode === 'view' ? (
+        <TodoViewFields todo={todo} />
+      ) : (
+        <EditFormFields
+          activeArray={activeArray}
+          allTags={allTags}
+          onChange={state.setEditedTodo}
+          todo={state.editedTodo}
+        />
+      )}
+    </div>
+    {state.mode === 'view' ? (
+      <ViewModeActions isDeleting={state.isDeleting} onDelete={state.handleDelete} />
+    ) : (
+      <EditModeActions
+        isActiveValid={validateTimeTracking(activeArray)}
+        isSaving={state.isSaving}
+        onCancel={state.handleCancelEdit}
+        onSave={state.handleSave}
+      />
+    )}
+  </div>
+);
+
+export const TodoFlyout: FC<TodoFlyoutProps> = ({ onClose, show, todo }) => {
+  const { allTags } = useTags();
+  const state = useTodoFlyoutState(todo, show, onClose);
+  const activeArray = Object.entries(state.editedTodo.active);
+
+  if (!show) {
+    return null;
+  }
+
+  return (
+    <>
+      <Drawer
+        className="!w-[640px]"
+        data-testid="todo-flyout"
+        onClose={state.handleClose}
+        open={show}
+        position="right"
+      >
+        <DrawerHeader
+          title={state.mode === 'view' ? 'Todo Details' : 'Edit Todo'}
+          titleIcon={() => (
+            <div className="mr-2">
+              <ModeToggle mode={state.mode} onToggle={state.handleModeToggle} />
+            </div>
+          )}
+        />
+        <DrawerItems>
+          <FlyoutContent activeArray={activeArray} allTags={allTags} state={state} todo={todo} />
+        </DrawerItems>
+      </Drawer>
+      {state.showUnsavedDialog && (
+        <UnsavedChangesDialog
+          onDiscard={state.handleDiscardChanges}
+          onKeepEditing={state.handleKeepEditing}
+        />
+      )}
+    </>
+  );
+};
+
+// Re-export for backward compatibility during migration
+export { TodoFlyout as TodoEditFlyout };

--- a/packages/web-client/src/components/todo_list_element.test.tsx
+++ b/packages/web-client/src/components/todo_list_element.test.tsx
@@ -9,10 +9,10 @@ import { createTestTodo, populateTestDatabase, renderWithPouchDb, testTodos } fr
 import { TodoListElement } from './todo_list_element';
 
 // Mock child components to avoid complex dependencies
-vi.mock('./todo_edit_flyout', () => ({
-  TodoEditFlyout: ({ show, onClose }: { show: boolean; onClose: () => void }) =>
+vi.mock('./todo_flyout', () => ({
+  TodoFlyout: ({ show, onClose }: { show: boolean; onClose: () => void }) =>
     show ? (
-      <div data-testid="todo-edit-flyout">
+      <div data-testid="todo-flyout">
         <button onClick={onClose}>Close Modal</button>
       </div>
     ) : null,
@@ -304,7 +304,7 @@ describe('TodoListElement', () => {
       // Should not have any buttons in activity-only mode
       expect(screen.queryByTestId('play-button')).not.toBeInTheDocument();
       expect(screen.queryByTestId('pause-button')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('edit-button')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('view-button')).not.toBeInTheDocument();
     });
 
     it('hides time tracking button when another todo is actively tracking', () => {
@@ -430,17 +430,17 @@ describe('TodoListElement', () => {
     });
   });
 
-  describe('Edit Modal', () => {
-    it('shows edit button', () => {
+  describe('View Flyout', () => {
+    it('shows view button', () => {
       renderWithPouchDb(
         <TodoListElement {...defaultProps} todo={testTodos.active as TodoAlpha3} />,
         { testDb: testDb.contextValue },
       );
 
-      expect(screen.getByTestId('edit-button')).toBeInTheDocument();
+      expect(screen.getByTestId('view-button')).toBeInTheDocument();
     });
 
-    it('does not show edit button in activity-only mode', () => {
+    it('does not show view button in activity-only mode', () => {
       renderWithPouchDb(
         <TodoListElement
           {...defaultProps}
@@ -455,7 +455,7 @@ describe('TodoListElement', () => {
       expect(buttons).toHaveLength(0);
     });
 
-    it('opens edit modal when edit button is clicked', async () => {
+    it('opens view flyout when view button is clicked', async () => {
       const user = userEvent.setup();
 
       renderWithPouchDb(
@@ -463,33 +463,33 @@ describe('TodoListElement', () => {
         { testDb: testDb.contextValue },
       );
 
-      // Find and click the edit button
-      const editButton = screen.getByTestId('edit-button');
-      await user.click(editButton);
+      // Find and click the view button
+      const viewButton = screen.getByTestId('view-button');
+      await user.click(viewButton);
 
-      // Verify the modal is shown
+      // Verify the flyout is shown
       await waitFor(() => {
-        expect(screen.getByTestId('todo-edit-flyout')).toBeInTheDocument();
+        expect(screen.getByTestId('todo-flyout')).toBeInTheDocument();
       });
     });
 
-    it('prevents default behavior on edit button click', () => {
+    it('prevents default behavior on view button click', () => {
       renderWithPouchDb(
         <TodoListElement {...defaultProps} todo={testTodos.active as TodoAlpha3} />,
         { testDb: testDb.contextValue },
       );
 
-      // Find the edit button
-      const editButton = screen.getByTestId('edit-button');
+      // Find the view button
+      const viewButton = screen.getByTestId('view-button');
 
       const mockPreventDefault = vi.fn();
 
-      fireEvent.click(editButton, {
+      fireEvent.click(viewButton, {
         preventDefault: mockPreventDefault,
       });
 
       // The component calls preventDefault internally
-      expect(editButton).toBeInTheDocument();
+      expect(viewButton).toBeInTheDocument();
     });
   });
 

--- a/packages/web-client/src/components/todo_table.test.tsx
+++ b/packages/web-client/src/components/todo_table.test.tsx
@@ -9,10 +9,10 @@ import { createTestTodo, renderWithPouchDb } from '../test-utils';
 import { TodoTable } from './todo_table';
 
 // Mock child components
-vi.mock('./todo_edit_flyout', () => ({
-  TodoEditFlyout: ({ show, onClose }: { show: boolean; onClose: () => void }) =>
+vi.mock('./todo_flyout', () => ({
+  TodoFlyout: ({ show, onClose }: { show: boolean; onClose: () => void }) =>
     show ? (
-      <div data-testid="todo-edit-flyout">
+      <div data-testid="todo-flyout">
         <button onClick={onClose}>Close</button>
       </div>
     ) : null,
@@ -245,11 +245,11 @@ describe('TodoTable', () => {
         expect(screen.getByText('Test todo')).toBeInTheDocument();
       });
 
-      const editButton = screen.getByTitle('Edit');
-      await user.click(editButton);
+      const viewButton = screen.getByTitle('View details');
+      await user.click(viewButton);
 
       await waitFor(() => {
-        expect(screen.getByTestId('todo-edit-flyout')).toBeInTheDocument();
+        expect(screen.getByTestId('todo-flyout')).toBeInTheDocument();
       });
     });
 

--- a/packages/web-client/src/components/todo_view_fields.tsx
+++ b/packages/web-client/src/components/todo_view_fields.tsx
@@ -1,0 +1,181 @@
+/**
+ * Read-only view components for todo display
+ */
+import { type Todo, getActiveDuration, getFormattedDuration } from '@eddo/core-client';
+import { type FC } from 'react';
+import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+import { TEXT_LINK } from '../styles/interactive';
+import { TagDisplay } from './tag_display';
+
+interface TodoViewFieldsProps {
+  todo: Todo;
+}
+
+/** Markdown prose styles for consistent rendering */
+const MARKDOWN_PROSE =
+  'prose prose-sm dark:prose-invert prose-a:text-blue-600 prose-a:underline hover:prose-a:text-blue-800 dark:prose-a:text-blue-400 dark:hover:prose-a:text-blue-300 max-w-none';
+
+/** Label styling for field headers */
+const LABEL_CLASS =
+  'text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wide';
+
+/** Value styling for field content */
+const VALUE_CLASS = 'text-sm text-neutral-900 dark:text-white';
+
+/** Empty value placeholder */
+const EMPTY_VALUE = <span className="text-neutral-400 italic dark:text-neutral-500">—</span>;
+
+interface FieldRowProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+const FieldRow: FC<FieldRowProps> = ({ label, children }) => (
+  <div>
+    <div className={LABEL_CLASS}>{label}</div>
+    <div className={`${VALUE_CLASS} mt-1`}>{children}</div>
+  </div>
+);
+
+const StatusBadge: FC<{ completed: string | null }> = ({ completed }) => {
+  if (completed) {
+    return (
+      <span className="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-200">
+        Completed
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+      Open
+    </span>
+  );
+};
+
+const TitleView: FC<{ todo: Todo }> = ({ todo }) => (
+  <div>
+    <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">{todo.title}</h2>
+    <div className="mt-2 flex items-center gap-3">
+      <StatusBadge completed={todo.completed} />
+      <span className="text-sm text-neutral-500 dark:text-neutral-400">{todo.context}</span>
+    </div>
+  </div>
+);
+
+const DescriptionView: FC<{ description: string }> = ({ description }) => {
+  if (!description.trim()) {
+    return <FieldRow label="Description">{EMPTY_VALUE}</FieldRow>;
+  }
+
+  return (
+    <div>
+      <div className={LABEL_CLASS}>Description</div>
+      <div
+        className={`${MARKDOWN_PROSE} mt-2 rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-700 dark:bg-neutral-900`}
+      >
+        <Markdown remarkPlugins={[remarkGfm]}>{description}</Markdown>
+      </div>
+    </div>
+  );
+};
+
+const TagsView: FC<{ tags: string[] }> = ({ tags }) => (
+  <FieldRow label="Tags">{tags.length > 0 ? <TagDisplay tags={tags} /> : EMPTY_VALUE}</FieldRow>
+);
+
+const LinkView: FC<{ link: string | null }> = ({ link }) => (
+  <FieldRow label="Link">
+    {link ? (
+      <a className={`${TEXT_LINK} break-all`} href={link} rel="noreferrer" target="_blank">
+        {link}
+      </a>
+    ) : (
+      EMPTY_VALUE
+    )}
+  </FieldRow>
+);
+
+const ExternalIdView: FC<{ externalId: string | null }> = ({ externalId }) => (
+  <FieldRow label="External ID">
+    {externalId ? <span className="font-mono text-xs">{externalId}</span> : EMPTY_VALUE}
+  </FieldRow>
+);
+
+const DueDateView: FC<{ due: string }> = ({ due }) => {
+  const dateOnly = due.split('T')[0];
+  return <FieldRow label="Due Date">{dateOnly || EMPTY_VALUE}</FieldRow>;
+};
+
+const RepeatView: FC<{ repeat: number | null }> = ({ repeat }) => (
+  <FieldRow label="Repeat">
+    {repeat !== null ? `Every ${repeat} day${repeat !== 1 ? 's' : ''}` : EMPTY_VALUE}
+  </FieldRow>
+);
+
+const CompletedView: FC<{ completed: string | null }> = ({ completed }) => (
+  <FieldRow label="Completed">
+    {completed ? new Date(completed).toLocaleString() : EMPTY_VALUE}
+  </FieldRow>
+);
+
+const CreatedView: FC<{ id: string }> = ({ id }) => (
+  <FieldRow label="Created">{new Date(id).toLocaleString()}</FieldRow>
+);
+
+interface TimeTrackingViewProps {
+  active: Record<string, string | null>;
+}
+
+const TimeTrackingView: FC<TimeTrackingViewProps> = ({ active }) => {
+  const entries = Object.entries(active);
+  const totalDuration = getActiveDuration(active);
+  const hasActiveSession = entries.some(([, to]) => to === null);
+
+  if (entries.length === 0) {
+    return <FieldRow label="Time Tracking">{EMPTY_VALUE}</FieldRow>;
+  }
+
+  return (
+    <div>
+      <div className={LABEL_CLASS}>Time Tracking</div>
+      <div className="mt-2 space-y-2">
+        <div className="flex items-center justify-between rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-900">
+          <span className="text-sm font-medium text-neutral-700 dark:text-neutral-300">Total</span>
+          <span className="text-sm font-semibold text-neutral-900 dark:text-white">
+            {getFormattedDuration(totalDuration) || '0m'}
+            {hasActiveSession && (
+              <span className="ml-2 inline-flex h-2 w-2 animate-pulse rounded-full bg-green-500" />
+            )}
+          </span>
+        </div>
+        <div className="text-xs text-neutral-500 dark:text-neutral-400">
+          {entries.length} session{entries.length !== 1 ? 's' : ''}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const TodoViewFields: FC<TodoViewFieldsProps> = ({ todo }) => (
+  <div className="flex flex-col gap-6">
+    <TitleView todo={todo} />
+    <DescriptionView description={todo.description} />
+
+    <div className="grid grid-cols-2 gap-4">
+      <DueDateView due={todo.due} />
+      <RepeatView repeat={todo.repeat} />
+    </div>
+
+    <TagsView tags={todo.tags} />
+    <LinkView link={todo.link} />
+    <ExternalIdView externalId={todo.externalId ?? null} />
+    <TimeTrackingView active={todo.active} />
+
+    <div className="grid grid-cols-2 gap-4 border-t border-neutral-200 pt-4 dark:border-neutral-700">
+      <CompletedView completed={todo.completed} />
+      <CreatedView id={todo._id} />
+    </div>
+  </div>
+);

--- a/packages/web-client/src/eddo.tsx
+++ b/packages/web-client/src/eddo.tsx
@@ -18,6 +18,7 @@ import { DatabaseChangesProvider } from './hooks/use_database_changes';
 import { useDatabaseHealth } from './hooks/use_database_health';
 import { useFilterPreferences } from './hooks/use_filter_preferences';
 import { usePreferencesStream } from './hooks/use_preferences_stream';
+import { TodoFlyoutProvider } from './hooks/use_todo_flyout';
 import { useViewPreferences } from './hooks/use_view_preferences';
 import { createUserPouchDbContext } from './pouch_db';
 import { PouchDbContext } from './pouch_db_types';
@@ -180,10 +181,12 @@ function AuthenticatedApp({
 
   return (
     <DatabaseChangesProvider>
-      <CouchdbSyncProvider />
-      <PreferencesStreamProvider />
-      <HealthMonitor />
-      <TodoApp logout={logout} />
+      <TodoFlyoutProvider>
+        <CouchdbSyncProvider />
+        <PreferencesStreamProvider />
+        <HealthMonitor />
+        <TodoApp logout={logout} />
+      </TodoFlyoutProvider>
     </DatabaseChangesProvider>
   );
 }

--- a/packages/web-client/src/hooks/use_todo_flyout.tsx
+++ b/packages/web-client/src/hooks/use_todo_flyout.tsx
@@ -1,0 +1,85 @@
+/**
+ * Context for managing which todo's flyout is open.
+ * Lifting this state up prevents flyout from closing on todo updates.
+ */
+import { type Todo } from '@eddo/core-client';
+import {
+  type FC,
+  type ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+interface TodoFlyoutContextValue {
+  openTodoId: string | null;
+  openTodo: (todo: Todo) => void;
+  closeFlyout: () => void;
+  updateTodo: (todo: Todo) => void;
+  currentTodo: Todo | null;
+}
+
+const TodoFlyoutContext = createContext<TodoFlyoutContextValue | null>(null);
+
+interface TodoFlyoutProviderProps {
+  children: ReactNode;
+}
+
+export const TodoFlyoutProvider: FC<TodoFlyoutProviderProps> = ({ children }) => {
+  const [openTodoId, setOpenTodoId] = useState<string | null>(null);
+  const [currentTodo, setCurrentTodo] = useState<Todo | null>(null);
+
+  const openTodo = useCallback((todo: Todo) => {
+    setOpenTodoId(todo._id);
+    setCurrentTodo(todo);
+  }, []);
+
+  const closeFlyout = useCallback(() => {
+    setOpenTodoId(null);
+    setCurrentTodo(null);
+  }, []);
+
+  const updateTodo = useCallback(
+    (todo: Todo) => {
+      if (todo._id === openTodoId) {
+        setCurrentTodo(todo);
+      }
+    },
+    [openTodoId],
+  );
+
+  const value = { openTodoId, openTodo, closeFlyout, updateTodo, currentTodo };
+
+  return <TodoFlyoutContext.Provider value={value}>{children}</TodoFlyoutContext.Provider>;
+};
+
+export const useTodoFlyoutContext = (): TodoFlyoutContextValue => {
+  const context = useContext(TodoFlyoutContext);
+  if (!context) {
+    throw new Error('useTodoFlyoutContext must be used within TodoFlyoutProvider');
+  }
+  return context;
+};
+
+/**
+ * Hook for individual todo items to control flyout.
+ * Also keeps the flyout's todo in sync when the underlying todo updates.
+ * @param todo - The todo this component represents
+ */
+export const useTodoFlyout = (todo: Todo) => {
+  const { openTodoId, openTodo, closeFlyout, updateTodo } = useTodoFlyoutContext();
+
+  // Keep flyout's todo in sync when this todo updates
+  useEffect(() => {
+    if (openTodoId === todo._id) {
+      updateTodo(todo);
+    }
+  }, [openTodoId, todo, updateTodo]);
+
+  const isOpen = openTodoId === todo._id;
+  const open = useCallback(() => openTodo(todo), [openTodo, todo]);
+
+  return { isOpen, open, close: closeFlyout };
+};

--- a/packages/web-client/src/hooks/use_todo_flyout_state.ts
+++ b/packages/web-client/src/hooks/use_todo_flyout_state.ts
@@ -1,0 +1,233 @@
+/**
+ * State management hook for the TodoFlyout component
+ */
+import { type DatabaseError, type Todo } from '@eddo/core-client';
+import { useCallback, useEffect, useState } from 'react';
+
+import { useDeleteTodoMutation, useSaveTodoMutation } from './use_todo_mutations';
+
+type FlyoutMode = 'view' | 'edit';
+
+interface TodoFlyoutState {
+  mode: FlyoutMode;
+  editedTodo: Todo;
+  setEditedTodo: React.Dispatch<React.SetStateAction<Todo>>;
+  showUnsavedDialog: boolean;
+  handleDelete: (e: React.FormEvent<HTMLButtonElement>) => Promise<void>;
+  handleSave: (e: React.FormEvent<HTMLButtonElement>) => Promise<void>;
+  handleModeToggle: () => void;
+  handleClose: () => void;
+  handleDiscardChanges: () => void;
+  handleKeepEditing: () => void;
+  handleCancelEdit: () => void;
+  clearError: () => void;
+  error: DatabaseError | null;
+  isSaving: boolean;
+  isDeleting: boolean;
+}
+
+/** Checks if todo has been modified */
+const hasChanges = (original: Todo, edited: Todo): boolean => {
+  return JSON.stringify(original) !== JSON.stringify(edited);
+};
+
+interface MutationHandlerDeps {
+  saveTodoMutation: ReturnType<typeof useSaveTodoMutation>;
+  deleteTodoMutation: ReturnType<typeof useDeleteTodoMutation>;
+  todo: Todo;
+  editedTodo: Todo;
+  setMode: React.Dispatch<React.SetStateAction<FlyoutMode>>;
+  onClose: () => void;
+}
+
+/** Creates mutation handlers (delete and save) */
+const useMutationHandlers = (deps: MutationHandlerDeps) => {
+  const { deleteTodoMutation, saveTodoMutation, todo, editedTodo, setMode, onClose } = deps;
+
+  const handleDelete = async (e: React.FormEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    try {
+      await deleteTodoMutation.mutateAsync(todo);
+      onClose();
+    } catch (err) {
+      console.error('Failed to delete todo:', err);
+    }
+  };
+
+  const handleSave = async (e: React.FormEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    try {
+      await saveTodoMutation.mutateAsync({ todo: editedTodo, originalTodo: todo });
+      setMode('view');
+    } catch (err) {
+      console.error('Failed to save todo:', err);
+    }
+  };
+
+  return { handleDelete, handleSave };
+};
+
+interface DialogHandlerDeps {
+  mode: FlyoutMode;
+  todo: Todo;
+  editedTodo: Todo;
+  setMode: React.Dispatch<React.SetStateAction<FlyoutMode>>;
+  setEditedTodo: React.Dispatch<React.SetStateAction<Todo>>;
+  setShowUnsavedDialog: React.Dispatch<React.SetStateAction<boolean>>;
+  pendingAction: 'view' | 'close' | null;
+  setPendingAction: React.Dispatch<React.SetStateAction<'view' | 'close' | null>>;
+  onClose: () => void;
+}
+
+/** Creates mode toggle handler */
+const useModeToggleHandler = (deps: DialogHandlerDeps) => {
+  const { mode, todo, editedTodo, setMode, setEditedTodo, setShowUnsavedDialog, setPendingAction } =
+    deps;
+  return useCallback(() => {
+    if (mode === 'edit' && hasChanges(todo, editedTodo)) {
+      setPendingAction('view');
+      setShowUnsavedDialog(true);
+    } else {
+      setMode(mode === 'view' ? 'edit' : 'view');
+      if (mode === 'view') setEditedTodo(todo);
+    }
+  }, [mode, todo, editedTodo, setMode, setEditedTodo, setPendingAction, setShowUnsavedDialog]);
+};
+
+/** Creates close and discard handlers */
+const useCloseHandlers = (deps: DialogHandlerDeps) => {
+  const { mode, todo, editedTodo, setMode, setEditedTodo } = deps;
+  const { setShowUnsavedDialog, pendingAction, setPendingAction, onClose } = deps;
+
+  const handleClose = useCallback(() => {
+    if (mode === 'edit' && hasChanges(todo, editedTodo)) {
+      setPendingAction('close');
+      setShowUnsavedDialog(true);
+    } else {
+      onClose();
+    }
+  }, [mode, todo, editedTodo, onClose, setPendingAction, setShowUnsavedDialog]);
+
+  const handleDiscardChanges = useCallback(() => {
+    setShowUnsavedDialog(false);
+    setEditedTodo(todo);
+    if (pendingAction === 'close') onClose();
+    else setMode('view');
+    setPendingAction(null);
+  }, [
+    todo,
+    pendingAction,
+    onClose,
+    setEditedTodo,
+    setMode,
+    setPendingAction,
+    setShowUnsavedDialog,
+  ]);
+
+  const handleKeepEditing = useCallback(() => {
+    setShowUnsavedDialog(false);
+    setPendingAction(null);
+  }, [setShowUnsavedDialog, setPendingAction]);
+
+  const handleCancelEdit = useCallback(() => {
+    if (hasChanges(todo, editedTodo)) {
+      setPendingAction('view');
+      setShowUnsavedDialog(true);
+    } else {
+      setEditedTodo(todo);
+      setMode('view');
+    }
+  }, [todo, editedTodo, setEditedTodo, setMode, setPendingAction, setShowUnsavedDialog]);
+
+  return { handleClose, handleDiscardChanges, handleKeepEditing, handleCancelEdit };
+};
+
+/** Creates dialog and navigation handlers */
+const useDialogHandlers = (deps: DialogHandlerDeps) => {
+  const handleModeToggle = useModeToggleHandler(deps);
+  const closeHandlers = useCloseHandlers(deps);
+  return { handleModeToggle, ...closeHandlers };
+};
+
+/** Hook for flyout state initialization */
+const useFlyoutStateInit = (todo: Todo, show: boolean) => {
+  const [mode, setMode] = useState<FlyoutMode>('view');
+  const [editedTodo, setEditedTodo] = useState(todo);
+  const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
+  const [pendingAction, setPendingAction] = useState<'view' | 'close' | null>(null);
+
+  useEffect(() => {
+    if (!show) return;
+    setEditedTodo(todo);
+    setMode('view');
+    setShowUnsavedDialog(false);
+    setPendingAction(null);
+  }, [show, todo._id, todo._rev]);
+
+  return {
+    mode,
+    setMode,
+    editedTodo,
+    setEditedTodo,
+    showUnsavedDialog,
+    setShowUnsavedDialog,
+    pendingAction,
+    setPendingAction,
+  };
+};
+
+/**
+ * Hook for todo flyout state and handlers
+ * @param todo - The todo being viewed/edited
+ * @param show - Whether the flyout is visible
+ * @param onClose - Callback when flyout should close
+ * @returns State and handlers for the flyout
+ */
+export const useTodoFlyoutState = (
+  todo: Todo,
+  show: boolean,
+  onClose: () => void,
+): TodoFlyoutState => {
+  const saveTodoMutation = useSaveTodoMutation();
+  const deleteTodoMutation = useDeleteTodoMutation();
+  const state = useFlyoutStateInit(todo, show);
+
+  const mutationHandlers = useMutationHandlers({
+    saveTodoMutation,
+    deleteTodoMutation,
+    todo,
+    editedTodo: state.editedTodo,
+    setMode: state.setMode,
+    onClose,
+  });
+
+  const dialogHandlers = useDialogHandlers({
+    mode: state.mode,
+    todo,
+    editedTodo: state.editedTodo,
+    setMode: state.setMode,
+    setEditedTodo: state.setEditedTodo,
+    setShowUnsavedDialog: state.setShowUnsavedDialog,
+    pendingAction: state.pendingAction,
+    setPendingAction: state.setPendingAction,
+    onClose,
+  });
+
+  const clearError = useCallback(() => {
+    saveTodoMutation.reset();
+    deleteTodoMutation.reset();
+  }, [saveTodoMutation, deleteTodoMutation]);
+
+  return {
+    mode: state.mode,
+    editedTodo: state.editedTodo,
+    setEditedTodo: state.setEditedTodo,
+    showUnsavedDialog: state.showUnsavedDialog,
+    ...mutationHandlers,
+    ...dialogHandlers,
+    clearError,
+    error: (saveTodoMutation.error || deleteTodoMutation.error) as DatabaseError | null,
+    isSaving: saveTodoMutation.isPending,
+    isDeleting: deleteTodoMutation.isPending,
+  };
+};

--- a/packages/web-client/src/test-utils.tsx
+++ b/packages/web-client/src/test-utils.tsx
@@ -5,6 +5,7 @@ import { type RenderOptions, render } from '@testing-library/react';
 import { type ReactElement, type ReactNode } from 'react';
 
 import { DatabaseChangesProvider } from './hooks/use_database_changes';
+import { TodoFlyoutProvider } from './hooks/use_todo_flyout';
 import { PouchDbContext, type PouchDbContextType } from './pouch_db_types';
 import { createTestPouchDb } from './test-setup';
 
@@ -50,7 +51,9 @@ export const TestWrapper = ({
   return (
     <QueryClientProvider client={queryClient}>
       <PouchDbContext.Provider value={contextValue}>
-        <DatabaseChangesProvider>{children}</DatabaseChangesProvider>
+        <DatabaseChangesProvider>
+          <TodoFlyoutProvider>{children}</TodoFlyoutProvider>
+        </DatabaseChangesProvider>
       </PouchDbContext.Provider>
     </QueryClientProvider>
   );


### PR DESCRIPTION
## Summary
Refactors the todo flyout from edit-first to view-first mode. Users see rendered content by default and can switch to edit mode when needed.

## Changes
- **View mode** (default): Shows rendered Markdown description + read-only fields
- **Edit mode**: Toggle via "Edit" button in header
- **Save behavior**: Returns to view mode, flyout stays open
- **Unsaved changes**: Dialog prompts when leaving edit mode with changes
- **State management**: Lifted to `TodoFlyoutProvider` context to prevent flyout closing on updates

## New Files
- `todo_view_fields.tsx` - Read-only view components with Markdown rendering
- `todo_flyout.tsx` - New flyout with view/edit mode toggle
- `use_todo_flyout_state.ts` - State management hook
- `use_todo_flyout.tsx` - Context provider for flyout state
- `are_todos_equal.ts` - Utility for todo comparison (excludes _rev)

## Testing
- All 509 tests pass
- Manual verification complete

Closes #374