### PR TITLE
test: add completed + due date range filter test

### DIFF
--- a/.changeset/add-completed-date-range-test.md
+++ b/.changeset/add-completed-date-range-test.md
@@ -1,0 +1,5 @@
+---
+'eddo-app': patch
+---
+
+Add integration test for completed todos with due date range filtering


### PR DESCRIPTION
Add integration test for `completed: true` combined with due date range filtering (`dateFrom`/`dateTo`).

Closes #347