### PR TITLE
feat: add filter presets for saving and applying filter configurations

### DIFF
--- a/.changeset/filter-presets.md
+++ b/.changeset/filter-presets.md
@@ -1,0 +1,5 @@
+---
+'eddo-app': minor
+---
+
+Add filter presets for saving and quickly applying filter configurations

--- a/packages/core-shared/src/versions/user_registry_alpha2.ts
+++ b/packages/core-shared/src/versions/user_registry_alpha2.ts
@@ -23,6 +23,41 @@ export interface RssFeedConfig {
 /** Email authentication provider type */
 export type EmailProvider = 'gmail' | 'imap';
 
+/** Date handling mode for filter presets */
+export type FilterPresetDateMode = 'relative' | 'fixed';
+
+/** Time range type for filter presets */
+export type FilterPresetTimeRangeType =
+  | 'current-day'
+  | 'current-week'
+  | 'current-month'
+  | 'current-year'
+  | 'all-time'
+  | 'custom';
+
+/** Time range configuration for filter presets */
+export interface FilterPresetTimeRange {
+  type: FilterPresetTimeRangeType;
+  startDate?: string;
+  endDate?: string;
+}
+
+/** Completion status for filter presets */
+export type FilterPresetStatus = 'all' | 'completed' | 'incomplete';
+
+/** Saved filter preset configuration */
+export interface FilterPreset {
+  id: string;
+  name: string;
+  selectedTags: string[];
+  selectedContexts: string[];
+  selectedStatus: FilterPresetStatus;
+  selectedTimeRange: FilterPresetTimeRange;
+  dateMode: FilterPresetDateMode;
+  savedDate?: string;
+  createdAt: string;
+}
+
 /** Email sync configuration */
 export interface EmailSyncConfig {
   /** Authentication provider (gmail for OAuth, imap for credentials) */
@@ -80,6 +115,8 @@ export interface UserPreferences {
   emailSyncInterval?: number; // Minutes between syncs, defaults to 15
   emailSyncTags?: string[]; // Tags to add to synced emails, defaults to ["source:email", "gtd:next"]
   emailLastSync?: string; // ISO timestamp of last successful sync
+  // Filter Presets
+  filterPresets?: FilterPreset[]; // Saved filter preset configurations
 }
 
 export interface UserRegistryEntryAlpha2 extends Omit<UserRegistryEntryAlpha1, 'version'> {

--- a/packages/web-api/src/routes/users-schemas.ts
+++ b/packages/web-api/src/routes/users-schemas.ts
@@ -71,4 +71,30 @@ export const updatePreferencesSchema = z.object({
     .optional(),
   rssSyncInterval: z.number().int().positive().optional(),
   rssSyncTags: z.array(z.string()).optional(),
+  filterPresets: z
+    .array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        selectedTags: z.array(z.string()),
+        selectedContexts: z.array(z.string()),
+        selectedStatus: z.enum(['all', 'completed', 'incomplete']),
+        selectedTimeRange: z.object({
+          type: z.enum([
+            'current-day',
+            'current-week',
+            'current-month',
+            'current-year',
+            'all-time',
+            'custom',
+          ]),
+          startDate: z.string().optional(),
+          endDate: z.string().optional(),
+        }),
+        dateMode: z.enum(['relative', 'fixed']),
+        savedDate: z.string().optional(),
+        createdAt: z.string(),
+      }),
+    )
+    .optional(),
 });

--- a/packages/web-client/src/components/preset_filter_button.tsx
+++ b/packages/web-client/src/components/preset_filter_button.tsx
@@ -1,0 +1,30 @@
+/**
+ * Preset filter dropdown trigger button
+ */
+import type { FC } from 'react';
+import { MdBookmark, MdBookmarkBorder } from 'react-icons/md';
+
+import { getFilterButtonClass } from '../styles/interactive';
+
+interface PresetFilterButtonProps {
+  hasPresets: boolean;
+  presetCount: number;
+  isOpen: boolean;
+  onClick: () => void;
+}
+
+export const PresetFilterButton: FC<PresetFilterButtonProps> = ({
+  hasPresets,
+  presetCount,
+  onClick,
+}) => (
+  <button className={getFilterButtonClass(hasPresets)} onClick={onClick} type="button">
+    {hasPresets ? <MdBookmark size="1.2em" /> : <MdBookmarkBorder size="1.2em" />}
+    <span>Presets</span>
+    {hasPresets && (
+      <span className="bg-primary-100 text-primary-800 dark:bg-primary-800 dark:text-primary-200 rounded-full px-2 py-0.5 text-xs">
+        {presetCount}
+      </span>
+    )}
+  </button>
+);

--- a/packages/web-client/src/components/preset_filter_content.tsx
+++ b/packages/web-client/src/components/preset_filter_content.tsx
@@ -1,0 +1,75 @@
+/**
+ * Preset dropdown content - list of presets and save form
+ */
+import type { FC } from 'react';
+import { MdBookmarkBorder } from 'react-icons/md';
+
+import { DROPDOWN_CONTAINER, FOCUS_RING, TRANSITION } from '../styles/interactive';
+
+import { SavePresetForm } from './preset_filter_form';
+import { PresetItem } from './preset_filter_item';
+import type { PresetDropdownContentProps } from './preset_filter_types';
+
+const EmptyState: FC = () => (
+  <p className="mb-3 text-sm text-neutral-500 dark:text-neutral-400">
+    No saved presets. Save your current filters for quick access.
+  </p>
+);
+
+const SaveButton: FC<{ onClick: () => void }> = ({ onClick }) => (
+  <button
+    className={`w-full ${TRANSITION} ${FOCUS_RING} hover:border-primary-500 hover:text-primary-600 dark:hover:border-primary-400 dark:hover:text-primary-400 flex items-center justify-center gap-2 rounded-lg border border-dashed border-neutral-300 px-3 py-2 text-sm text-neutral-600 dark:border-neutral-600 dark:text-neutral-400`}
+    onClick={onClick}
+    type="button"
+  >
+    <MdBookmarkBorder size="1.2em" />
+    Save current filters
+  </button>
+);
+
+export const PresetDropdownContent: FC<PresetDropdownContentProps> = ({
+  presets,
+  isLoading,
+  showSaveForm,
+  onApply,
+  onRename,
+  onDelete,
+  onSave,
+  onShowSaveForm,
+  onHideSaveForm,
+}) => {
+  const hasPresets = presets.length > 0;
+
+  return (
+    <div className={`top-full w-72 p-3 ${DROPDOWN_CONTAINER}`}>
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+          Filter Presets
+        </h3>
+      </div>
+
+      {hasPresets && (
+        <div className="mb-3 space-y-1">
+          {presets.map((preset) => (
+            <PresetItem
+              isLoading={isLoading}
+              key={preset.id}
+              onApply={() => onApply(preset)}
+              onDelete={() => onDelete(preset.id)}
+              onRename={(newName) => onRename(preset.id, newName)}
+              preset={preset}
+            />
+          ))}
+        </div>
+      )}
+
+      {!hasPresets && !showSaveForm && <EmptyState />}
+
+      {showSaveForm ? (
+        <SavePresetForm isLoading={isLoading} onCancel={onHideSaveForm} onSave={onSave} />
+      ) : (
+        <SaveButton onClick={onShowSaveForm} />
+      )}
+    </div>
+  );
+};

--- a/packages/web-client/src/components/preset_filter_dropdown.tsx
+++ b/packages/web-client/src/components/preset_filter_dropdown.tsx
@@ -1,0 +1,52 @@
+/**
+ * Dropdown for managing and applying filter presets
+ */
+import { type FC, useState } from 'react';
+
+import { usePresetHandlers } from '../hooks/use_preset_handlers';
+
+import { PresetFilterButton } from './preset_filter_button';
+import { PresetDropdownContent } from './preset_filter_content';
+import type { PresetFilterDropdownProps } from './preset_filter_types';
+
+export const PresetFilterDropdown: FC<PresetFilterDropdownProps> = ({
+  currentFilters,
+  onApplyPreset,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleClose = () => {
+    setIsOpen(false);
+    handlers.setShowSaveForm(false);
+  };
+
+  const handlers = usePresetHandlers({ currentFilters, onApplyPreset, onClose: handleClose });
+  const hasPresets = handlers.presets.length > 0;
+
+  return (
+    <div className="relative">
+      <PresetFilterButton
+        hasPresets={hasPresets}
+        isOpen={isOpen}
+        onClick={() => setIsOpen(!isOpen)}
+        presetCount={handlers.presets.length}
+      />
+      {isOpen && (
+        <>
+          <div className="fixed inset-0 z-10" onClick={handleClose} />
+          <PresetDropdownContent
+            isLoading={handlers.isLoading || handlers.isOperating}
+            onApply={handlers.handleApply}
+            onDelete={handlers.handleDelete}
+            onHideSaveForm={() => handlers.setShowSaveForm(false)}
+            onRename={handlers.handleRename}
+            onSave={handlers.handleSave}
+            onShowSaveForm={() => handlers.setShowSaveForm(true)}
+            presets={handlers.presets}
+            showSaveForm={handlers.showSaveForm}
+          />
+        </>
+      )}
+    </div>
+  );
+};

--- a/packages/web-client/src/components/preset_filter_form.tsx
+++ b/packages/web-client/src/components/preset_filter_form.tsx
@@ -1,0 +1,82 @@
+/**
+ * Save preset form component
+ */
+import { type FC, useState } from 'react';
+
+import { BTN_PRIMARY_SM, CLEAR_BUTTON, INPUT_BASE } from '../styles/interactive';
+
+import type { SavePresetFormProps } from './preset_filter_types';
+
+interface FormInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  isLoading: boolean;
+}
+
+const FormInput: FC<FormInputProps> = ({ value, onChange, isLoading }) => (
+  <div>
+    <label
+      className="mb-1 block text-xs text-neutral-500 dark:text-neutral-400"
+      htmlFor="preset-name"
+    >
+      Preset name
+    </label>
+    <input
+      autoFocus
+      className={`w-full ${INPUT_BASE}`}
+      disabled={isLoading}
+      id="preset-name"
+      onChange={(e) => onChange(e.target.value)}
+      placeholder="e.g., Today's tasks"
+      type="text"
+      value={value}
+    />
+  </div>
+);
+
+interface DateCheckboxProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  isLoading: boolean;
+}
+
+const DateCheckbox: FC<DateCheckboxProps> = ({ checked, onChange, isLoading }) => (
+  <label className="flex cursor-pointer items-center gap-2 text-sm text-neutral-700 dark:text-neutral-300">
+    <input
+      checked={checked}
+      className="text-primary-600 focus:ring-primary-500 rounded border-neutral-300"
+      disabled={isLoading}
+      onChange={(e) => onChange(e.target.checked)}
+      type="checkbox"
+    />
+    Always use current date
+  </label>
+);
+
+export const SavePresetForm: FC<SavePresetFormProps> = ({ onSave, onCancel, isLoading }) => {
+  const [name, setName] = useState('');
+  const [useRelativeDate, setUseRelativeDate] = useState(true);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (name.trim()) onSave(name.trim(), useRelativeDate);
+  };
+
+  return (
+    <form
+      className="space-y-3 border-t border-neutral-200 pt-3 dark:border-neutral-600"
+      onSubmit={handleSubmit}
+    >
+      <FormInput isLoading={isLoading} onChange={setName} value={name} />
+      <DateCheckbox checked={useRelativeDate} isLoading={isLoading} onChange={setUseRelativeDate} />
+      <div className="flex gap-2">
+        <button className={BTN_PRIMARY_SM} disabled={!name.trim() || isLoading} type="submit">
+          {isLoading ? 'Saving...' : 'Save'}
+        </button>
+        <button className={CLEAR_BUTTON} disabled={isLoading} onClick={onCancel} type="button">
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+};

--- a/packages/web-client/src/components/preset_filter_item.tsx
+++ b/packages/web-client/src/components/preset_filter_item.tsx
@@ -1,0 +1,131 @@
+/**
+ * Individual preset item with edit/delete actions
+ */
+import { type FC, useState } from 'react';
+import { MdBookmark, MdDelete, MdEdit } from 'react-icons/md';
+
+import { DROPDOWN_ITEM, ICON_BUTTON, INPUT_BASE } from '../styles/interactive';
+
+import type { PresetItemProps } from './preset_filter_types';
+
+interface EditingInputProps {
+  value: string;
+  isLoading: boolean;
+  onChange: (value: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}
+
+const EditingInput: FC<EditingInputProps> = ({ value, isLoading, onChange, onSave, onCancel }) => {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') onSave();
+    else if (e.key === 'Escape') onCancel();
+  };
+
+  return (
+    <div className="flex items-center gap-2 px-2 py-1">
+      <input
+        autoFocus
+        className={`flex-1 ${INPUT_BASE} py-0.5 text-sm`}
+        disabled={isLoading}
+        onBlur={onSave}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        type="text"
+        value={value}
+      />
+    </div>
+  );
+};
+
+interface PresetButtonProps {
+  name: string;
+  isFixed: boolean;
+  isLoading: boolean;
+  onApply: () => void;
+}
+
+const PresetButton: FC<PresetButtonProps> = ({ name, isFixed, isLoading, onApply }) => (
+  <button
+    className={`flex-1 ${DROPDOWN_ITEM} flex items-center gap-2`}
+    disabled={isLoading}
+    onClick={onApply}
+    type="button"
+  >
+    <MdBookmark className="text-primary-500" size="1em" />
+    <span className="truncate">{name}</span>
+    {isFixed && <span className="ml-auto text-xs text-neutral-400">fixed</span>}
+  </button>
+);
+
+interface ActionButtonsProps {
+  isLoading: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+const ActionButtons: FC<ActionButtonsProps> = ({ isLoading, onEdit, onDelete }) => (
+  <>
+    <button
+      className={`${ICON_BUTTON} opacity-0 group-hover:opacity-100`}
+      disabled={isLoading}
+      onClick={onEdit}
+      title="Rename"
+      type="button"
+    >
+      <MdEdit size="1em" />
+    </button>
+    <button
+      className={`${ICON_BUTTON} opacity-0 group-hover:opacity-100 hover:text-red-500`}
+      disabled={isLoading}
+      onClick={onDelete}
+      title="Delete"
+      type="button"
+    >
+      <MdDelete size="1em" />
+    </button>
+  </>
+);
+
+export const PresetItem: FC<PresetItemProps> = ({
+  preset,
+  onApply,
+  onRename,
+  onDelete,
+  isLoading,
+}) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editName, setEditName] = useState(preset.name);
+
+  const handleSave = () => {
+    if (editName.trim() && editName.trim() !== preset.name) onRename(editName.trim());
+    setIsEditing(false);
+  };
+
+  if (isEditing) {
+    return (
+      <EditingInput
+        isLoading={isLoading}
+        onCancel={() => {
+          setEditName(preset.name);
+          setIsEditing(false);
+        }}
+        onChange={setEditName}
+        onSave={handleSave}
+        value={editName}
+      />
+    );
+  }
+
+  return (
+    <div className="group flex items-center gap-1">
+      <PresetButton
+        isFixed={preset.dateMode === 'fixed'}
+        isLoading={isLoading}
+        name={preset.name}
+        onApply={onApply}
+      />
+      <ActionButtons isLoading={isLoading} onDelete={onDelete} onEdit={() => setIsEditing(true)} />
+    </div>
+  );
+};

--- a/packages/web-client/src/components/preset_filter_types.ts
+++ b/packages/web-client/src/components/preset_filter_types.ts
@@ -1,0 +1,44 @@
+/**
+ * Type definitions for preset filter components
+ */
+import type { CurrentFilterState } from '../hooks/use_filter_presets';
+import type { FilterPreset } from '../hooks/use_profile_types';
+
+export interface PresetFilterDropdownProps {
+  currentFilters: CurrentFilterState;
+  onApplyPreset: (filters: CurrentFilterState) => void;
+}
+
+export interface SavePresetFormProps {
+  onSave: (name: string, useRelativeDate: boolean) => void;
+  onCancel: () => void;
+  isLoading: boolean;
+}
+
+export interface PresetItemProps {
+  preset: FilterPreset;
+  onApply: () => void;
+  onRename: (newName: string) => void;
+  onDelete: () => void;
+  isLoading: boolean;
+}
+
+export interface PresetListProps {
+  presets: FilterPreset[];
+  isLoading: boolean;
+  onApply: (preset: FilterPreset) => void;
+  onRename: (id: string, newName: string) => void;
+  onDelete: (id: string) => void;
+}
+
+export interface PresetDropdownContentProps {
+  presets: FilterPreset[];
+  isLoading: boolean;
+  showSaveForm: boolean;
+  onApply: (preset: FilterPreset) => void;
+  onRename: (id: string, newName: string) => void;
+  onDelete: (id: string) => void;
+  onSave: (name: string, useRelativeDate: boolean) => void;
+  onShowSaveForm: () => void;
+  onHideSaveForm: () => void;
+}

--- a/packages/web-client/src/components/todo_filters.test.tsx
+++ b/packages/web-client/src/components/todo_filters.test.tsx
@@ -25,6 +25,17 @@ vi.mock('../hooks/use_eddo_contexts', () => ({
   }),
 }));
 
+vi.mock('../hooks/use_filter_presets', () => ({
+  useFilterPresets: () => ({
+    presets: [],
+    isLoading: false,
+    createPreset: vi.fn(),
+    updatePreset: vi.fn(),
+    deletePreset: vi.fn(),
+    applyPreset: vi.fn(),
+  }),
+}));
+
 // Mock date-fns to make tests deterministic
 vi.mock('date-fns', async () => {
   const actual = await vi.importActual('date-fns');

--- a/packages/web-client/src/components/todo_filters.tsx
+++ b/packages/web-client/src/components/todo_filters.tsx
@@ -1,180 +1,58 @@
-import { add, format, getISOWeek, sub } from 'date-fns';
-import { Button } from 'flowbite-react';
-import { type FC } from 'react';
-import { RiArrowLeftSLine, RiArrowRightSLine } from 'react-icons/ri';
-
-import { FOCUS_RING, TRANSITION } from '../styles/interactive';
+/**
+ * Todo filters toolbar component
+ */
+import { type FC, useCallback } from 'react';
 
 import { useEddoContexts } from '../hooks/use_eddo_contexts';
+import type { CurrentFilterState } from '../hooks/use_filter_presets';
 import { useTags } from '../hooks/use_tags';
-import type { ViewMode } from '../hooks/use_view_preferences';
-import { ColumnPicker } from './column_picker';
-import { EddoContextFilter } from './eddo_context_filter';
-import type { CompletionStatus } from './status_filter';
-import { StatusFilter } from './status_filter';
-import { TagFilter } from './tag_filter';
-import type { TimeRange } from './time_range_filter';
-import { TimeRangeFilter } from './time_range_filter';
-import { ViewModeToggle } from './view_mode_toggle';
 
-interface TodoFiltersProps {
-  currentDate: Date;
-  setCurrentDate: (date: Date) => void;
-  selectedTags: string[];
-  setSelectedTags: (tags: string[]) => void;
-  selectedContexts: string[];
-  setSelectedContexts: (contexts: string[]) => void;
-  selectedStatus: CompletionStatus;
-  setSelectedStatus: (status: CompletionStatus) => void;
-  selectedTimeRange: TimeRange;
-  setSelectedTimeRange: (timeRange: TimeRange) => void;
-  viewMode: ViewMode;
-  onViewModeChange: (mode: ViewMode) => void;
-  tableColumns: string[];
-  onTableColumnsChange: (columns: string[]) => void;
-  isViewPrefsLoading?: boolean;
-}
+import { navigatePeriod } from './todo_filters_helpers';
+import { PeriodNavigation } from './todo_filters_navigation';
+import { FilterRow } from './todo_filters_row';
+import type { TodoFiltersProps } from './todo_filters_types';
 
-const getPeriodLabel = (currentDate: Date, timeRange: TimeRange): string => {
-  switch (timeRange.type) {
-    case 'current-day':
-      return format(currentDate, 'MMM d, yyyy');
-    case 'current-week':
-      return `CW${getISOWeek(currentDate)}`;
-    case 'current-month':
-      return format(currentDate, 'MMM yyyy');
-    case 'current-year':
-      return format(currentDate, 'yyyy');
-    case 'custom':
-      if (timeRange.startDate && timeRange.endDate) {
-        const start = format(new Date(timeRange.startDate), 'MMM d');
-        const end = format(new Date(timeRange.endDate), 'MMM d, yyyy');
-        return `${start} - ${end}`;
+export type { CompletionStatus } from './status_filter';
+export type { TimeRange } from './time_range_filter';
+export type { TodoFiltersProps } from './todo_filters_types';
+
+/** Build preset apply handler - uses batch update if available */
+function useApplyPresetHandler(props: TodoFiltersProps) {
+  return useCallback(
+    (filters: CurrentFilterState) => {
+      if (props.batchUpdateFilters) {
+        // Use batch update to avoid conflicts
+        props.batchUpdateFilters({
+          selectedTags: filters.selectedTags,
+          selectedContexts: filters.selectedContexts,
+          selectedStatus: filters.selectedStatus,
+          selectedTimeRange: filters.selectedTimeRange,
+          currentDate: filters.currentDate,
+        });
+      } else {
+        // Fallback to individual setters
+        props.setSelectedTags(filters.selectedTags);
+        props.setSelectedContexts(filters.selectedContexts);
+        props.setSelectedStatus(filters.selectedStatus);
+        props.setSelectedTimeRange(filters.selectedTimeRange);
+        props.setCurrentDate(filters.currentDate);
       }
-      return 'Custom Range';
-    case 'all-time':
-      return 'All Time';
-    default:
-      return 'Period';
-  }
-};
-
-const getCustomRangeDays = (timeRange: TimeRange): number => {
-  if (!timeRange.startDate || !timeRange.endDate) return 0;
-  const start = new Date(timeRange.startDate);
-  const end = new Date(timeRange.endDate);
-  return (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24);
-};
-
-const navigatePeriod = (
-  currentDate: Date,
-  timeRange: TimeRange,
-  direction: 'prev' | 'next',
-): Date => {
-  const addOrSub = direction === 'next' ? add : sub;
-  switch (timeRange.type) {
-    case 'current-day':
-      return addOrSub(currentDate, { days: 1 });
-    case 'current-week':
-      return addOrSub(currentDate, { weeks: 1 });
-    case 'current-month':
-      return addOrSub(currentDate, { months: 1 });
-    case 'current-year':
-      return addOrSub(currentDate, { years: 1 });
-    case 'custom':
-      return addOrSub(currentDate, { days: getCustomRangeDays(timeRange) });
-    default:
-      return currentDate;
-  }
-};
-
-interface FilterRowProps {
-  viewMode: ViewMode;
-  isViewPrefsLoading: boolean;
-  tableColumns: string[];
-  onViewModeChange: (mode: ViewMode) => void;
-  onTableColumnsChange: (columns: string[]) => void;
-  selectedTimeRange: TimeRange;
-  setSelectedTimeRange: (timeRange: TimeRange) => void;
-  selectedStatus: CompletionStatus;
-  setSelectedStatus: (status: CompletionStatus) => void;
-  allContexts: string[];
-  selectedContexts: string[];
-  setSelectedContexts: (contexts: string[]) => void;
-  allTags: string[];
-  selectedTags: string[];
-  setSelectedTags: (tags: string[]) => void;
-}
-
-const FilterRow: FC<FilterRowProps> = (props) => (
-  <>
-    <ViewModeToggle
-      isLoading={props.isViewPrefsLoading}
-      onViewModeChange={props.onViewModeChange}
-      viewMode={props.viewMode}
-    />
-    {props.viewMode === 'table' && (
-      <ColumnPicker
-        onColumnsChange={props.onTableColumnsChange}
-        selectedColumns={props.tableColumns}
-      />
-    )}
-    <TimeRangeFilter
-      onTimeRangeChange={props.setSelectedTimeRange}
-      selectedTimeRange={props.selectedTimeRange}
-    />
-    <StatusFilter onStatusChange={props.setSelectedStatus} selectedStatus={props.selectedStatus} />
-    <EddoContextFilter
-      availableContexts={props.allContexts}
-      onContextsChange={props.setSelectedContexts}
-      selectedContexts={props.selectedContexts}
-    />
-    <TagFilter
-      availableTags={props.allTags}
-      onTagsChange={props.setSelectedTags}
-      selectedTags={props.selectedTags}
-    />
-  </>
-);
-
-interface PeriodNavigationProps {
-  currentDate: Date;
-  selectedTimeRange: TimeRange;
-  onNavigate: (direction: 'prev' | 'next') => void;
-  onReset: () => void;
-}
-
-const PeriodNavigation: FC<PeriodNavigationProps> = ({
-  currentDate,
-  selectedTimeRange,
-  onNavigate,
-  onReset,
-}) => {
-  if (selectedTimeRange.type === 'all-time') return null;
-
-  return (
-    <>
-      <Button className="p-0" color="gray" onClick={() => onNavigate('prev')} size="xs">
-        <RiArrowLeftSLine size="2em" />
-      </Button>{' '}
-      <button
-        className={`cursor-pointer font-semibold ${TRANSITION} hover:text-primary-600 dark:hover:text-primary-400 rounded-lg text-neutral-900 dark:text-white ${FOCUS_RING}`}
-        onClick={onReset}
-        title="Return to current period"
-        type="button"
-      >
-        {getPeriodLabel(currentDate, selectedTimeRange)}
-      </button>{' '}
-      <Button className="p-0" color="gray" onClick={() => onNavigate('next')} size="xs">
-        <RiArrowRightSLine size="2em" />
-      </Button>
-    </>
+    },
+    [
+      props.batchUpdateFilters,
+      props.setSelectedTags,
+      props.setSelectedContexts,
+      props.setSelectedStatus,
+      props.setSelectedTimeRange,
+      props.setCurrentDate,
+    ],
   );
-};
+}
 
 export const TodoFilters: FC<TodoFiltersProps> = (props) => {
   const { allTags } = useTags();
   const { allContexts } = useEddoContexts();
+  const handleApplyPreset = useApplyPresetHandler(props);
 
   const handleNavigate = (direction: 'prev' | 'next') => {
     props.setCurrentDate(navigatePeriod(props.currentDate, props.selectedTimeRange, direction));
@@ -185,7 +63,9 @@ export const TodoFilters: FC<TodoFiltersProps> = (props) => {
       <FilterRow
         allContexts={allContexts}
         allTags={allTags}
+        currentDate={props.currentDate}
         isViewPrefsLoading={props.isViewPrefsLoading ?? false}
+        onApplyPreset={handleApplyPreset}
         onTableColumnsChange={props.onTableColumnsChange}
         onViewModeChange={props.onViewModeChange}
         selectedContexts={props.selectedContexts}

--- a/packages/web-client/src/components/todo_filters_helpers.ts
+++ b/packages/web-client/src/components/todo_filters_helpers.ts
@@ -1,0 +1,62 @@
+/**
+ * Helper functions for todo filters
+ */
+import { add, format, getISOWeek, sub } from 'date-fns';
+
+import type { TimeRange } from './time_range_filter';
+
+/** Format the period label based on current date and time range */
+export function getPeriodLabel(currentDate: Date, timeRange: TimeRange): string {
+  switch (timeRange.type) {
+    case 'current-day':
+      return format(currentDate, 'MMM d, yyyy');
+    case 'current-week':
+      return `CW${getISOWeek(currentDate)}`;
+    case 'current-month':
+      return format(currentDate, 'MMM yyyy');
+    case 'current-year':
+      return format(currentDate, 'yyyy');
+    case 'custom':
+      if (timeRange.startDate && timeRange.endDate) {
+        const start = format(new Date(timeRange.startDate), 'MMM d');
+        const end = format(new Date(timeRange.endDate), 'MMM d, yyyy');
+        return `${start} - ${end}`;
+      }
+      return 'Custom Range';
+    case 'all-time':
+      return 'All Time';
+    default:
+      return 'Period';
+  }
+}
+
+/** Calculate the number of days in a custom range */
+function getCustomRangeDays(timeRange: TimeRange): number {
+  if (!timeRange.startDate || !timeRange.endDate) return 0;
+  const start = new Date(timeRange.startDate);
+  const end = new Date(timeRange.endDate);
+  return (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24);
+}
+
+/** Navigate to the next or previous period */
+export function navigatePeriod(
+  currentDate: Date,
+  timeRange: TimeRange,
+  direction: 'prev' | 'next',
+): Date {
+  const addOrSub = direction === 'next' ? add : sub;
+  switch (timeRange.type) {
+    case 'current-day':
+      return addOrSub(currentDate, { days: 1 });
+    case 'current-week':
+      return addOrSub(currentDate, { weeks: 1 });
+    case 'current-month':
+      return addOrSub(currentDate, { months: 1 });
+    case 'current-year':
+      return addOrSub(currentDate, { years: 1 });
+    case 'custom':
+      return addOrSub(currentDate, { days: getCustomRangeDays(timeRange) });
+    default:
+      return currentDate;
+  }
+}

--- a/packages/web-client/src/components/todo_filters_navigation.tsx
+++ b/packages/web-client/src/components/todo_filters_navigation.tsx
@@ -1,0 +1,39 @@
+/**
+ * Period navigation component for todo filters
+ */
+import { Button } from 'flowbite-react';
+import type { FC } from 'react';
+import { RiArrowLeftSLine, RiArrowRightSLine } from 'react-icons/ri';
+
+import { FOCUS_RING, TRANSITION } from '../styles/interactive';
+
+import { getPeriodLabel } from './todo_filters_helpers';
+import type { PeriodNavigationProps } from './todo_filters_types';
+
+export const PeriodNavigation: FC<PeriodNavigationProps> = ({
+  currentDate,
+  selectedTimeRange,
+  onNavigate,
+  onReset,
+}) => {
+  if (selectedTimeRange.type === 'all-time') return null;
+
+  return (
+    <>
+      <Button className="p-0" color="gray" onClick={() => onNavigate('prev')} size="xs">
+        <RiArrowLeftSLine size="2em" />
+      </Button>{' '}
+      <button
+        className={`cursor-pointer font-semibold ${TRANSITION} hover:text-primary-600 dark:hover:text-primary-400 rounded-lg text-neutral-900 dark:text-white ${FOCUS_RING}`}
+        onClick={onReset}
+        title="Return to current period"
+        type="button"
+      >
+        {getPeriodLabel(currentDate, selectedTimeRange)}
+      </button>{' '}
+      <Button className="p-0" color="gray" onClick={() => onNavigate('next')} size="xs">
+        <RiArrowRightSLine size="2em" />
+      </Button>
+    </>
+  );
+};

--- a/packages/web-client/src/components/todo_filters_row.tsx
+++ b/packages/web-client/src/components/todo_filters_row.tsx
@@ -1,0 +1,54 @@
+/**
+ * Filter row component with all filter dropdowns
+ */
+import type { FC } from 'react';
+
+import { ColumnPicker } from './column_picker';
+import { EddoContextFilter } from './eddo_context_filter';
+import { PresetFilterDropdown } from './preset_filter_dropdown';
+import { StatusFilter } from './status_filter';
+import { TagFilter } from './tag_filter';
+import { TimeRangeFilter } from './time_range_filter';
+import type { FilterRowProps } from './todo_filters_types';
+import { ViewModeToggle } from './view_mode_toggle';
+
+export const FilterRow: FC<FilterRowProps> = (props) => (
+  <>
+    <ViewModeToggle
+      isLoading={props.isViewPrefsLoading}
+      onViewModeChange={props.onViewModeChange}
+      viewMode={props.viewMode}
+    />
+    {props.viewMode === 'table' && (
+      <ColumnPicker
+        onColumnsChange={props.onTableColumnsChange}
+        selectedColumns={props.tableColumns}
+      />
+    )}
+    <PresetFilterDropdown
+      currentFilters={{
+        selectedTags: props.selectedTags,
+        selectedContexts: props.selectedContexts,
+        selectedStatus: props.selectedStatus,
+        selectedTimeRange: props.selectedTimeRange,
+        currentDate: props.currentDate,
+      }}
+      onApplyPreset={props.onApplyPreset}
+    />
+    <TimeRangeFilter
+      onTimeRangeChange={props.setSelectedTimeRange}
+      selectedTimeRange={props.selectedTimeRange}
+    />
+    <StatusFilter onStatusChange={props.setSelectedStatus} selectedStatus={props.selectedStatus} />
+    <EddoContextFilter
+      availableContexts={props.allContexts}
+      onContextsChange={props.setSelectedContexts}
+      selectedContexts={props.selectedContexts}
+    />
+    <TagFilter
+      availableTags={props.allTags}
+      onTagsChange={props.setSelectedTags}
+      selectedTags={props.selectedTags}
+    />
+  </>
+);

--- a/packages/web-client/src/components/todo_filters_types.ts
+++ b/packages/web-client/src/components/todo_filters_types.ts
@@ -1,0 +1,57 @@
+/**
+ * Type definitions for todo filters components
+ */
+import type { BatchFilterUpdate } from '../hooks/use_filter_preferences';
+import type { CurrentFilterState } from '../hooks/use_filter_presets';
+import type { ViewMode } from '../hooks/use_view_preferences';
+
+import type { CompletionStatus } from './status_filter';
+import type { TimeRange } from './time_range_filter';
+
+export interface TodoFiltersProps {
+  currentDate: Date;
+  setCurrentDate: (date: Date) => void;
+  selectedTags: string[];
+  setSelectedTags: (tags: string[]) => void;
+  selectedContexts: string[];
+  setSelectedContexts: (contexts: string[]) => void;
+  selectedStatus: CompletionStatus;
+  setSelectedStatus: (status: CompletionStatus) => void;
+  selectedTimeRange: TimeRange;
+  setSelectedTimeRange: (timeRange: TimeRange) => void;
+  viewMode: ViewMode;
+  onViewModeChange: (mode: ViewMode) => void;
+  tableColumns: string[];
+  onTableColumnsChange: (columns: string[]) => void;
+  isViewPrefsLoading?: boolean;
+  batchUpdateFilters?: (
+    updates: BatchFilterUpdate,
+  ) => Promise<{ success: boolean; error?: string }>;
+}
+
+export interface FilterRowProps {
+  viewMode: ViewMode;
+  isViewPrefsLoading: boolean;
+  tableColumns: string[];
+  onViewModeChange: (mode: ViewMode) => void;
+  onTableColumnsChange: (columns: string[]) => void;
+  selectedTimeRange: TimeRange;
+  setSelectedTimeRange: (timeRange: TimeRange) => void;
+  selectedStatus: CompletionStatus;
+  setSelectedStatus: (status: CompletionStatus) => void;
+  allContexts: string[];
+  selectedContexts: string[];
+  setSelectedContexts: (contexts: string[]) => void;
+  allTags: string[];
+  selectedTags: string[];
+  setSelectedTags: (tags: string[]) => void;
+  currentDate: Date;
+  onApplyPreset: (filters: CurrentFilterState) => void;
+}
+
+export interface PeriodNavigationProps {
+  currentDate: Date;
+  selectedTimeRange: TimeRange;
+  onNavigate: (direction: 'prev' | 'next') => void;
+  onReset: () => void;
+}

--- a/packages/web-client/src/eddo.tsx
+++ b/packages/web-client/src/eddo.tsx
@@ -88,6 +88,7 @@ function TodoFiltersSection({
   const { viewMode, tableColumns, isLoading, setViewMode, setTableColumns } = viewPrefs;
   return (
     <TodoFilters
+      batchUpdateFilters={prefs.batchUpdate}
       currentDate={prefs.currentDate}
       isViewPrefsLoading={isLoading}
       onTableColumnsChange={async (cols) => {

--- a/packages/web-client/src/hooks/use_filter_preferences.ts
+++ b/packages/web-client/src/hooks/use_filter_preferences.ts
@@ -19,6 +19,15 @@ export interface FilterPreferences {
   currentDate: Date;
 }
 
+/** Batch update data for applying presets */
+export interface BatchFilterUpdate {
+  selectedTags?: string[];
+  selectedContexts?: string[];
+  selectedStatus?: CompletionStatus;
+  selectedTimeRange?: TimeRange;
+  currentDate?: Date;
+}
+
 export interface UseFilterPreferencesReturn {
   selectedTags: string[];
   selectedContexts: string[];
@@ -32,6 +41,7 @@ export interface UseFilterPreferencesReturn {
   setSelectedStatus: (status: CompletionStatus) => Promise<{ success: boolean; error?: string }>;
   setSelectedTimeRange: (timeRange: TimeRange) => Promise<{ success: boolean; error?: string }>;
   setCurrentDate: (date: Date) => Promise<{ success: boolean; error?: string }>;
+  batchUpdate: (updates: BatchFilterUpdate) => Promise<{ success: boolean; error?: string }>;
 }
 
 /** Create preference setters bound to updatePreferences */
@@ -47,6 +57,18 @@ function createPreferenceSetters(
     setSelectedTimeRange: async (timeRange: TimeRange) =>
       updatePreferences({ selectedTimeRange: timeRange }),
     setCurrentDate: async (date: Date) => updatePreferences({ currentDate: date.toISOString() }),
+    batchUpdate: async (updates: BatchFilterUpdate) => {
+      const payload: Record<string, unknown> = {};
+      if (updates.selectedTags !== undefined) payload.selectedTags = updates.selectedTags;
+      if (updates.selectedContexts !== undefined)
+        payload.selectedContexts = updates.selectedContexts;
+      if (updates.selectedStatus !== undefined) payload.selectedStatus = updates.selectedStatus;
+      if (updates.selectedTimeRange !== undefined)
+        payload.selectedTimeRange = updates.selectedTimeRange;
+      if (updates.currentDate !== undefined)
+        payload.currentDate = updates.currentDate.toISOString();
+      return updatePreferences(payload);
+    },
   };
 }
 

--- a/packages/web-client/src/hooks/use_filter_presets.test.ts
+++ b/packages/web-client/src/hooks/use_filter_presets.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for filter presets hook helpers
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  type CreatePresetData,
+  createFilterPreset,
+  generatePresetId,
+  presetToFilterState,
+} from './use_filter_presets_helpers';
+import type { FilterPreset } from './use_profile_types';
+
+describe('useFilterPresets helpers', () => {
+  describe('generatePresetId', () => {
+    it('generates unique IDs', () => {
+      const id1 = generatePresetId();
+      const id2 = generatePresetId();
+
+      expect(id1).not.toBe(id2);
+      expect(id1).toMatch(/^preset_\d+_[a-z0-9]+$/);
+      expect(id2).toMatch(/^preset_\d+_[a-z0-9]+$/);
+    });
+
+    it('includes timestamp prefix', () => {
+      const before = Date.now();
+      const id = generatePresetId();
+      const after = Date.now();
+
+      const timestampPart = parseInt(id.split('_')[1], 10);
+      expect(timestampPart).toBeGreaterThanOrEqual(before);
+      expect(timestampPart).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe('createFilterPreset', () => {
+    const baseData: CreatePresetData = {
+      name: 'Test Preset',
+      filters: {
+        selectedTags: ['tag1', 'tag2'],
+        selectedContexts: ['work'],
+        selectedStatus: 'incomplete',
+        selectedTimeRange: { type: 'current-week' },
+        currentDate: new Date('2026-01-06T12:00:00.000Z'),
+      },
+      useRelativeDate: true,
+    };
+
+    it('creates preset with relative date mode', () => {
+      const preset = createFilterPreset(baseData);
+
+      expect(preset.name).toBe('Test Preset');
+      expect(preset.selectedTags).toEqual(['tag1', 'tag2']);
+      expect(preset.selectedContexts).toEqual(['work']);
+      expect(preset.selectedStatus).toBe('incomplete');
+      expect(preset.selectedTimeRange).toEqual({ type: 'current-week' });
+      expect(preset.dateMode).toBe('relative');
+      expect(preset.savedDate).toBeUndefined();
+      expect(preset.id).toMatch(/^preset_/);
+      expect(preset.createdAt).toBeDefined();
+    });
+
+    it('creates preset with fixed date mode', () => {
+      const data: CreatePresetData = {
+        ...baseData,
+        useRelativeDate: false,
+      };
+
+      const preset = createFilterPreset(data);
+
+      expect(preset.dateMode).toBe('fixed');
+      expect(preset.savedDate).toBe('2026-01-06T12:00:00.000Z');
+    });
+
+    it('trims whitespace from name', () => {
+      const data: CreatePresetData = {
+        ...baseData,
+        name: '  Trimmed Name  ',
+      };
+
+      const preset = createFilterPreset(data);
+
+      expect(preset.name).toBe('Trimmed Name');
+    });
+
+    it('creates deep copies of arrays', () => {
+      const preset = createFilterPreset(baseData);
+
+      // Mutating original should not affect preset
+      baseData.filters.selectedTags.push('tag3');
+      baseData.filters.selectedContexts.push('home');
+
+      expect(preset.selectedTags).toEqual(['tag1', 'tag2']);
+      expect(preset.selectedContexts).toEqual(['work']);
+    });
+  });
+
+  describe('presetToFilterState', () => {
+    it('converts relative preset to filter state with current date', () => {
+      const preset: FilterPreset = {
+        id: 'test-id',
+        name: 'Test',
+        selectedTags: ['tag1'],
+        selectedContexts: ['work'],
+        selectedStatus: 'completed',
+        selectedTimeRange: { type: 'current-day' },
+        dateMode: 'relative',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      };
+
+      const before = Date.now();
+      const state = presetToFilterState(preset);
+      const after = Date.now();
+
+      expect(state.selectedTags).toEqual(['tag1']);
+      expect(state.selectedContexts).toEqual(['work']);
+      expect(state.selectedStatus).toBe('completed');
+      expect(state.selectedTimeRange).toEqual({ type: 'current-day' });
+
+      // Current date should be close to now
+      expect(state.currentDate.getTime()).toBeGreaterThanOrEqual(before);
+      expect(state.currentDate.getTime()).toBeLessThanOrEqual(after);
+    });
+
+    it('converts fixed preset to filter state with saved date', () => {
+      const preset: FilterPreset = {
+        id: 'test-id',
+        name: 'Test',
+        selectedTags: [],
+        selectedContexts: [],
+        selectedStatus: 'all',
+        selectedTimeRange: { type: 'custom', startDate: '2025-10-01', endDate: '2025-12-31' },
+        dateMode: 'fixed',
+        savedDate: '2025-10-15T00:00:00.000Z',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      };
+
+      const state = presetToFilterState(preset);
+
+      expect(state.currentDate.toISOString()).toBe('2025-10-15T00:00:00.000Z');
+      expect(state.selectedTimeRange).toEqual({
+        type: 'custom',
+        startDate: '2025-10-01',
+        endDate: '2025-12-31',
+      });
+    });
+
+    it('creates deep copies of arrays', () => {
+      const preset: FilterPreset = {
+        id: 'test-id',
+        name: 'Test',
+        selectedTags: ['tag1'],
+        selectedContexts: ['work'],
+        selectedStatus: 'all',
+        selectedTimeRange: { type: 'current-week' },
+        dateMode: 'relative',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      };
+
+      const state = presetToFilterState(preset);
+
+      // Mutating state should not affect original preset
+      state.selectedTags.push('tag2');
+      state.selectedContexts.push('home');
+
+      expect(preset.selectedTags).toEqual(['tag1']);
+      expect(preset.selectedContexts).toEqual(['work']);
+    });
+  });
+});

--- a/packages/web-client/src/hooks/use_filter_presets.ts
+++ b/packages/web-client/src/hooks/use_filter_presets.ts
@@ -1,0 +1,69 @@
+/**
+ * Hook for managing filter presets CRUD operations
+ */
+import { useCallback, useMemo } from 'react';
+
+import {
+  type CreatePresetData,
+  type CurrentFilterState,
+  type UpdatePresetData,
+  createFilterPreset,
+  presetToFilterState,
+} from './use_filter_presets_helpers';
+import { useProfile } from './use_profile';
+import type { FilterPreset, ProfileResult } from './use_profile_types';
+
+export type { CreatePresetData, CurrentFilterState, UpdatePresetData };
+
+export interface UseFilterPresetsReturn {
+  presets: FilterPreset[];
+  isLoading: boolean;
+  createPreset: (data: CreatePresetData) => Promise<ProfileResult>;
+  updatePreset: (data: UpdatePresetData) => Promise<ProfileResult>;
+  deletePreset: (id: string) => Promise<ProfileResult>;
+  applyPreset: (preset: FilterPreset) => CurrentFilterState;
+}
+
+/** Hook for managing filter presets */
+export function useFilterPresets(): UseFilterPresetsReturn {
+  const { profile, isLoading, updatePreferences } = useProfile();
+  const presets = useMemo(() => profile?.preferences?.filterPresets ?? [], [profile]);
+
+  const createPreset = useCallback(
+    async (data: CreatePresetData): Promise<ProfileResult> => {
+      if (!data.name.trim()) return { success: false, error: 'Preset name is required' };
+      const newPreset = createFilterPreset(data);
+      return updatePreferences({ filterPresets: [...presets, newPreset] });
+    },
+    [presets, updatePreferences],
+  );
+
+  const updatePreset = useCallback(
+    async (data: UpdatePresetData): Promise<ProfileResult> => {
+      const idx = presets.findIndex((p) => p.id === data.id);
+      if (idx === -1) return { success: false, error: 'Preset not found' };
+      if (data.name !== undefined && !data.name.trim()) {
+        return { success: false, error: 'Preset name is required' };
+      }
+      const updated = [...presets];
+      updated[idx] = { ...updated[idx], ...(data.name && { name: data.name.trim() }) };
+      return updatePreferences({ filterPresets: updated });
+    },
+    [presets, updatePreferences],
+  );
+
+  const deletePreset = useCallback(
+    async (id: string): Promise<ProfileResult> => {
+      const filtered = presets.filter((p) => p.id !== id);
+      if (filtered.length === presets.length) return { success: false, error: 'Preset not found' };
+      return updatePreferences({ filterPresets: filtered });
+    },
+    [presets, updatePreferences],
+  );
+
+  const applyPreset = useCallback((preset: FilterPreset): CurrentFilterState => {
+    return presetToFilterState(preset);
+  }, []);
+
+  return { presets, isLoading, createPreset, updatePreset, deletePreset, applyPreset };
+}

--- a/packages/web-client/src/hooks/use_filter_presets_helpers.ts
+++ b/packages/web-client/src/hooks/use_filter_presets_helpers.ts
@@ -1,0 +1,72 @@
+/**
+ * Helper functions for filter presets hook
+ */
+import type { CompletionStatus } from '../components/status_filter';
+import type { TimeRange } from '../components/time_range_filter';
+
+import type { FilterPreset } from './use_profile_types';
+
+/** Current filter state to save as a preset */
+export interface CurrentFilterState {
+  selectedTags: string[];
+  selectedContexts: string[];
+  selectedStatus: CompletionStatus;
+  selectedTimeRange: TimeRange;
+  currentDate: Date;
+}
+
+/** Data for creating a new preset */
+export interface CreatePresetData {
+  name: string;
+  filters: CurrentFilterState;
+  useRelativeDate: boolean;
+}
+
+/** Data for updating an existing preset */
+export interface UpdatePresetData {
+  id: string;
+  name?: string;
+}
+
+/** Generate a unique ID for a new preset */
+export function generatePresetId(): string {
+  return `preset_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+}
+
+/** Create a FilterPreset from current filter state */
+export function createFilterPreset(data: CreatePresetData): FilterPreset {
+  return {
+    id: generatePresetId(),
+    name: data.name.trim(),
+    selectedTags: [...data.filters.selectedTags],
+    selectedContexts: [...data.filters.selectedContexts],
+    selectedStatus: data.filters.selectedStatus,
+    selectedTimeRange: { ...data.filters.selectedTimeRange },
+    dateMode: data.useRelativeDate ? 'relative' : 'fixed',
+    savedDate: data.useRelativeDate ? undefined : data.filters.currentDate.toISOString(),
+    createdAt: new Date().toISOString(),
+  };
+}
+
+/** Convert a preset back to filter state for applying */
+export function presetToFilterState(preset: FilterPreset): CurrentFilterState {
+  const currentDate =
+    preset.dateMode === 'relative' ? new Date() : new Date(preset.savedDate ?? new Date());
+
+  return {
+    selectedTags: [...preset.selectedTags],
+    selectedContexts: [...preset.selectedContexts],
+    selectedStatus: preset.selectedStatus,
+    selectedTimeRange: { ...preset.selectedTimeRange },
+    currentDate,
+  };
+}
+
+/** Update a preset in the list by ID */
+export function updatePresetInList(
+  presets: FilterPreset[],
+  id: string,
+  updates: Partial<Pick<FilterPreset, 'name'>>,
+): FilterPreset[] {
+  return presets.map((p) => (p.id === id ? { ...p, ...updates } : p));
+}

--- a/packages/web-client/src/hooks/use_preset_handlers.ts
+++ b/packages/web-client/src/hooks/use_preset_handlers.ts
@@ -1,0 +1,96 @@
+/**
+ * Hook for preset dropdown event handlers
+ */
+import { useCallback, useState } from 'react';
+
+import type { CurrentFilterState } from './use_filter_presets';
+import { useFilterPresets } from './use_filter_presets';
+import type { FilterPreset } from './use_profile_types';
+
+interface UsePresetHandlersOptions {
+  currentFilters: CurrentFilterState;
+  onApplyPreset: (filters: CurrentFilterState) => void;
+  onClose: () => void;
+}
+
+export interface UsePresetHandlersReturn {
+  presets: FilterPreset[];
+  isLoading: boolean;
+  isOperating: boolean;
+  showSaveForm: boolean;
+  setShowSaveForm: (show: boolean) => void;
+  handleSave: (name: string, useRelativeDate: boolean) => Promise<void>;
+  handleApply: (preset: FilterPreset) => void;
+  handleRename: (id: string, newName: string) => Promise<void>;
+  handleDelete: (id: string) => Promise<void>;
+}
+
+/** Create save handler bound to createPreset */
+function useSaveHandler(
+  createPreset: ReturnType<typeof useFilterPresets>['createPreset'],
+  currentFilters: CurrentFilterState,
+  setIsOperating: (v: boolean) => void,
+  setShowSaveForm: (v: boolean) => void,
+) {
+  return useCallback(
+    async (name: string, useRelativeDate: boolean) => {
+      setIsOperating(true);
+      const result = await createPreset({ name, filters: currentFilters, useRelativeDate });
+      setIsOperating(false);
+      if (result.success) setShowSaveForm(false);
+    },
+    [createPreset, currentFilters, setIsOperating, setShowSaveForm],
+  );
+}
+
+/** Hook for managing preset dropdown handlers */
+export function usePresetHandlers({
+  currentFilters,
+  onApplyPreset,
+  onClose,
+}: UsePresetHandlersOptions): UsePresetHandlersReturn {
+  const [showSaveForm, setShowSaveForm] = useState(false);
+  const [isOperating, setIsOperating] = useState(false);
+  const { presets, isLoading, createPreset, updatePreset, deletePreset, applyPreset } =
+    useFilterPresets();
+
+  const handleSave = useSaveHandler(createPreset, currentFilters, setIsOperating, setShowSaveForm);
+
+  const handleApply = useCallback(
+    (preset: FilterPreset) => {
+      onApplyPreset(applyPreset(preset));
+      onClose();
+    },
+    [applyPreset, onApplyPreset, onClose],
+  );
+
+  const handleRename = useCallback(
+    async (id: string, newName: string) => {
+      setIsOperating(true);
+      await updatePreset({ id, name: newName });
+      setIsOperating(false);
+    },
+    [updatePreset],
+  );
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      setIsOperating(true);
+      await deletePreset(id);
+      setIsOperating(false);
+    },
+    [deletePreset],
+  );
+
+  return {
+    presets,
+    isLoading,
+    isOperating,
+    showSaveForm,
+    setShowSaveForm,
+    handleSave,
+    handleApply,
+    handleRename,
+    handleDelete,
+  };
+}

--- a/packages/web-client/src/hooks/use_profile_types.ts
+++ b/packages/web-client/src/hooks/use_profile_types.ts
@@ -12,6 +12,41 @@ export interface RssFeedConfigUI {
   addedAt: string;
 }
 
+/** Date handling mode for filter presets */
+export type FilterPresetDateMode = 'relative' | 'fixed';
+
+/** Time range type for filter presets */
+export type FilterPresetTimeRangeType =
+  | 'current-day'
+  | 'current-week'
+  | 'current-month'
+  | 'current-year'
+  | 'all-time'
+  | 'custom';
+
+/** Time range configuration for filter presets */
+export interface FilterPresetTimeRange {
+  type: FilterPresetTimeRangeType;
+  startDate?: string;
+  endDate?: string;
+}
+
+/** Completion status for filter presets */
+export type FilterPresetStatus = 'all' | 'completed' | 'incomplete';
+
+/** Saved filter preset configuration */
+export interface FilterPreset {
+  id: string;
+  name: string;
+  selectedTags: string[];
+  selectedContexts: string[];
+  selectedStatus: FilterPresetStatus;
+  selectedTimeRange: FilterPresetTimeRange;
+  dateMode: FilterPresetDateMode;
+  savedDate?: string;
+  createdAt: string;
+}
+
 export interface UserPreferences {
   dailyBriefing: boolean;
   briefingTime?: string;
@@ -53,6 +88,7 @@ export interface UserPreferences {
   emailSyncInterval?: number;
   emailSyncTags?: string[];
   emailLastSync?: string;
+  filterPresets?: FilterPreset[];
 }
 
 export interface UserProfile {
@@ -115,6 +151,7 @@ export interface UpdatePreferencesData {
   emailFolder?: string;
   emailSyncInterval?: number;
   emailSyncTags?: string[];
+  filterPresets?: FilterPreset[];
 }
 
 export interface GithubResyncResponse {


### PR DESCRIPTION
## Summary

Add user preset filters - CRUD for saved filter configurations.

Closes #331

## Features

- **Save current filters** as a named preset via popover
- **Apply preset** with single click to restore all filter settings
- **Rename/delete** presets inline in the dropdown
- **Date mode**: Choose "relative" (always current date) or "fixed" (saved date)

## Implementation

- New `FilterPreset` type added to `UserPreferences`
- `useFilterPresets` hook for CRUD operations
- `PresetFilterDropdown` component in filter toolbar
- Batch update API to avoid CouchDB conflicts when applying presets
- 9 new unit tests for preset helpers

## Files Changed

- 14 new component/hook files for preset feature
- Updated `core-shared` and `web-api` for type/schema support
- Added `batchUpdate` to `useFilterPreferences` hook