### PR TITLE
feat(web-client): inline tag editing in table view

### DIFF
--- a/.changeset/inline-tag-editing.md
+++ b/.changeset/inline-tag-editing.md
@@ -1,0 +1,5 @@
+---
+'eddo-app': minor
+---
+
+Add inline editing of tags in table view

--- a/packages/web-client/src/components/tags_popover.test.tsx
+++ b/packages/web-client/src/components/tags_popover.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * Tests for TagsPopover component
+ */
+import '@testing-library/jest-dom';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import '../test-polyfill';
+import { createTestPouchDb, destroyTestPouchDb } from '../test-setup';
+import { createTestTodo, renderWithPouchDb } from '../test-utils';
+import { TagsPopover } from './tags_popover';
+
+// Mock the useTags hook
+vi.mock('../hooks/use_tags', () => ({
+  useTags: () => ({
+    allTags: ['work', 'personal', 'urgent', 'gtd:next'],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+// Mock the InlineTagInput to simplify testing
+vi.mock('./tags_popover_input', () => ({
+  InlineTagInput: ({
+    onChange,
+    tags,
+    autoFocus: _autoFocus,
+    suggestions: _suggestions,
+  }: {
+    onChange: (tags: string[]) => void;
+    tags: string[];
+    autoFocus?: boolean;
+    suggestions?: string[];
+  }) => (
+    <div data-testid="inline-tag-input">
+      <input
+        data-testid="tag-input-field"
+        onChange={(e) => {
+          const value = e.target.value;
+          const newTags = value
+            ? value
+                .split(',')
+                .map((tag) => tag.trim())
+                .filter(Boolean)
+            : [];
+          onChange(newTags);
+        }}
+        placeholder="Add tags..."
+        value={tags.join(',')}
+      />
+    </div>
+  ),
+}));
+
+describe('TagsPopover', () => {
+  let testDb: ReturnType<typeof createTestPouchDb>;
+
+  beforeEach(() => {
+    testDb = createTestPouchDb();
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await destroyTestPouchDb(testDb.db);
+  });
+
+  describe('rendering', () => {
+    it('should render tags when todo has tags', () => {
+      const todo = {
+        ...createTestTodo({ _id: '2025-01-15T10:00:00.000Z' }),
+        _rev: '1-abc',
+        tags: ['work', 'urgent'],
+      };
+
+      renderWithPouchDb(<TagsPopover todo={todo} />, { testDb: testDb.contextValue });
+
+      expect(screen.getByText('work')).toBeInTheDocument();
+      expect(screen.getByText('urgent')).toBeInTheDocument();
+    });
+
+    it('should render placeholder when todo has no tags', () => {
+      const todo = {
+        ...createTestTodo({ _id: '2025-01-15T10:00:00.000Z' }),
+        _rev: '1-abc',
+        tags: [],
+      };
+
+      renderWithPouchDb(<TagsPopover todo={todo} />, { testDb: testDb.contextValue });
+
+      expect(screen.getByText('Add tags...')).toBeInTheDocument();
+    });
+
+    it('should show +N indicator when more than 3 tags', () => {
+      const todo = {
+        ...createTestTodo({ _id: '2025-01-15T10:00:00.000Z' }),
+        _rev: '1-abc',
+        tags: ['tag1', 'tag2', 'tag3', 'tag4', 'tag5'],
+      };
+
+      renderWithPouchDb(<TagsPopover todo={todo} />, { testDb: testDb.contextValue });
+
+      expect(screen.getByText('tag1')).toBeInTheDocument();
+      expect(screen.getByText('tag2')).toBeInTheDocument();
+      expect(screen.getByText('tag3')).toBeInTheDocument();
+      expect(screen.getByText('+2')).toBeInTheDocument();
+    });
+  });
+
+  describe('interactions', () => {
+    it('should open popover when clicked', async () => {
+      const todo = {
+        ...createTestTodo({ _id: '2025-01-15T10:00:00.000Z' }),
+        _rev: '1-abc',
+        tags: ['work'],
+      };
+
+      renderWithPouchDb(<TagsPopover todo={todo} />, { testDb: testDb.contextValue });
+
+      const trigger = screen.getByTitle('Edit tags');
+      fireEvent.click(trigger);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('inline-tag-input')).toBeInTheDocument();
+      });
+    });
+
+    it('should close popover on escape key', async () => {
+      const todo = {
+        ...createTestTodo({ _id: '2025-01-15T10:00:00.000Z' }),
+        _rev: '1-abc',
+        tags: ['work'],
+      };
+
+      renderWithPouchDb(<TagsPopover todo={todo} />, { testDb: testDb.contextValue });
+
+      const trigger = screen.getByTitle('Edit tags');
+      fireEvent.click(trigger);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('inline-tag-input')).toBeInTheDocument();
+      });
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('inline-tag-input')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should call mutation when tags change on close', async () => {
+      const safePutSpy = vi.spyOn(testDb.contextValue.safeDb, 'safePut').mockResolvedValue({
+        _id: '2025-01-15T10:00:00.000Z',
+        _rev: '2-def',
+      } as never);
+
+      const todo = {
+        ...createTestTodo({ _id: '2025-01-15T10:00:00.000Z' }),
+        _rev: '1-abc',
+        tags: ['work'],
+      };
+
+      renderWithPouchDb(<TagsPopover todo={todo} />, { testDb: testDb.contextValue });
+
+      const trigger = screen.getByTitle('Edit tags');
+      fireEvent.click(trigger);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('inline-tag-input')).toBeInTheDocument();
+      });
+
+      // Change tags in the input
+      const input = screen.getByTestId('tag-input-field');
+      fireEvent.change(input, { target: { value: 'work,newtag' } });
+
+      // Close popover by pressing escape
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(safePutSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            tags: ['work', 'newtag'],
+          }),
+        );
+      });
+    });
+
+    it('should not save if tags unchanged', async () => {
+      const safePutSpy = vi.spyOn(testDb.contextValue.safeDb, 'safePut');
+
+      const todo = {
+        ...createTestTodo({ _id: '2025-01-15T10:00:00.000Z' }),
+        _rev: '1-abc',
+        tags: ['work'],
+      };
+
+      renderWithPouchDb(<TagsPopover todo={todo} />, { testDb: testDb.contextValue });
+
+      const trigger = screen.getByTitle('Edit tags');
+      fireEvent.click(trigger);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('inline-tag-input')).toBeInTheDocument();
+      });
+
+      // Close without making changes
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('inline-tag-input')).not.toBeInTheDocument();
+      });
+
+      // Should not have called safePut since tags didn't change
+      expect(safePutSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/web-client/src/components/tags_popover.tsx
+++ b/packages/web-client/src/components/tags_popover.tsx
@@ -1,0 +1,163 @@
+/**
+ * TagsPopover component for inline tag editing in table view
+ */
+import type { Todo } from '@eddo/core-client';
+import { useQueryClient } from '@tanstack/react-query';
+import { type FC, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { useTags } from '../hooks/use_tags';
+import { useTodoMutation } from '../hooks/use_todo_mutations';
+import { TRANSITION_FAST } from '../styles/interactive';
+import { TagDisplay } from './tag_display';
+import { InlineTagInput } from './tags_popover_input';
+
+interface TagsPopoverProps {
+  todo: Todo;
+}
+
+interface PopoverPosition {
+  top: number;
+  left: number;
+}
+
+const POPOVER_STYLES =
+  'fixed z-50 min-w-64 rounded-lg border border-neutral-200 bg-white p-2 shadow-lg dark:border-neutral-600 dark:bg-neutral-800';
+
+interface TagsPopoverMenuProps {
+  position: PopoverPosition;
+  tags: string[];
+  suggestions: string[];
+  onClose: () => void;
+  onSave: (tags: string[]) => void;
+}
+
+/**
+ * Hook for popover dismiss behavior (click outside, escape key)
+ */
+const usePopoverDismiss = (
+  menuRef: React.RefObject<HTMLDivElement | null>,
+  onClose: () => void,
+): void => {
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [menuRef, onClose]);
+};
+
+const TagsPopoverMenu: FC<TagsPopoverMenuProps> = ({
+  position,
+  tags,
+  suggestions,
+  onClose,
+  onSave,
+}) => {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [localTags, setLocalTags] = useState(tags);
+
+  usePopoverDismiss(menuRef, () => {
+    onSave(localTags);
+    onClose();
+  });
+
+  return createPortal(
+    <div
+      className={`${POPOVER_STYLES} ${TRANSITION_FAST}`}
+      ref={menuRef}
+      style={{ top: position.top, left: position.left }}
+    >
+      <InlineTagInput
+        autoFocus
+        onChange={setLocalTags}
+        suggestions={suggestions}
+        tags={localTags}
+      />
+    </div>,
+    document.body,
+  );
+};
+
+/**
+ * Trigger button that displays current tags
+ */
+interface TagsTriggerProps {
+  tags: string[];
+  onClick: (e: React.MouseEvent) => void;
+  buttonRef: React.RefObject<HTMLButtonElement | null>;
+}
+
+const TagsTrigger: FC<TagsTriggerProps> = ({ tags, onClick, buttonRef }) => (
+  <button
+    className="hover:bg-primary-50 dark:hover:bg-primary-900/30 -mx-1 cursor-pointer rounded px-1 py-0.5"
+    onClick={onClick}
+    ref={buttonRef}
+    title="Edit tags"
+    type="button"
+  >
+    {tags.length > 0 ? (
+      <TagDisplay maxTags={3} size="xs" tags={tags} />
+    ) : (
+      <span className="text-xs text-neutral-400">Add tags...</span>
+    )}
+  </button>
+);
+
+export const TagsPopover: FC<TagsPopoverProps> = ({ todo }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [position, setPosition] = useState<PopoverPosition>({ top: 0, left: 0 });
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const updateTodo = useTodoMutation();
+  const queryClient = useQueryClient();
+  const { allTags } = useTags();
+
+  const handleSave = async (newTags: string[]) => {
+    const tagsChanged =
+      newTags.length !== todo.tags.length || newTags.some((tag, i) => tag !== todo.tags[i]);
+
+    if (tagsChanged) {
+      await updateTodo.mutateAsync({ ...todo, tags: newTags });
+      queryClient.invalidateQueries({ queryKey: ['todos'] });
+    }
+  };
+
+  const handleToggle = (e: React.MouseEvent) => {
+    e.stopPropagation();
+
+    if (!isOpen && buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      setPosition({
+        top: rect.bottom + 4,
+        left: rect.left,
+      });
+    }
+
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <>
+      <TagsTrigger buttonRef={buttonRef} onClick={handleToggle} tags={todo.tags} />
+      {isOpen && (
+        <TagsPopoverMenu
+          onClose={() => setIsOpen(false)}
+          onSave={handleSave}
+          position={position}
+          suggestions={allTags}
+          tags={todo.tags}
+        />
+      )}
+    </>
+  );
+};

--- a/packages/web-client/src/components/tags_popover_input.tsx
+++ b/packages/web-client/src/components/tags_popover_input.tsx
@@ -1,0 +1,264 @@
+/**
+ * Inline tag input component for use in popovers
+ * Compact variant of TagInput without outer border
+ */
+import { type FC, useCallback, useEffect } from 'react';
+
+import { DROPDOWN_CONTAINER, DROPDOWN_ITEM } from '../styles/interactive';
+import {
+  filterSuggestions,
+  handleNavigationKey,
+  useClickOutside,
+  useTagInputState,
+} from './tag_input_helpers';
+
+interface InlineTagInputProps {
+  tags: string[];
+  onChange: (tags: string[]) => void;
+  suggestions?: string[];
+  autoFocus?: boolean;
+}
+
+interface TagBadgeProps {
+  tag: string;
+  onRemove: () => void;
+}
+
+const TagBadge: FC<TagBadgeProps> = ({ tag, onRemove }) => (
+  <span className="bg-primary-100 text-primary-800 dark:bg-primary-900 dark:text-primary-300 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium">
+    {tag}
+    <button
+      className="text-primary-600 hover:text-primary-800 dark:text-primary-400 dark:hover:text-primary-200 ml-1"
+      onClick={onRemove}
+      type="button"
+    >
+      ×
+    </button>
+  </span>
+);
+
+interface SuggestionListProps {
+  suggestions: string[];
+  selectedIndex: number;
+  onSelect: (suggestion: string) => void;
+  suggestionsRef: React.RefObject<HTMLDivElement | null>;
+}
+
+const SuggestionList: FC<SuggestionListProps> = ({
+  suggestions,
+  selectedIndex,
+  onSelect,
+  suggestionsRef,
+}) => (
+  <div className={`top-full w-full p-1 ${DROPDOWN_CONTAINER}`} ref={suggestionsRef}>
+    {suggestions.slice(0, 5).map((suggestion, index) => (
+      <button
+        className={`${DROPDOWN_ITEM} ${index === selectedIndex ? 'bg-primary-100 dark:bg-primary-900' : ''}`}
+        key={suggestion}
+        onClick={() => onSelect(suggestion)}
+        type="button"
+      >
+        {suggestion}
+      </button>
+    ))}
+  </div>
+);
+
+interface TagActionsParams {
+  tags: string[];
+  onChange: (tags: string[]) => void;
+  state: ReturnType<typeof useTagInputState>;
+}
+
+const useTagActions = ({ tags, onChange, state }: TagActionsParams) => {
+  const addTag = useCallback(
+    (tag: string) => {
+      const trimmedTag = tag.trim();
+      if (trimmedTag && !tags.includes(trimmedTag)) onChange([...tags, trimmedTag]);
+      state.reset();
+    },
+    [tags, onChange, state],
+  );
+
+  const removeTag = useCallback(
+    (tagToRemove: string) => onChange(tags.filter((t) => t !== tagToRemove)),
+    [tags, onChange],
+  );
+
+  return { addTag, removeTag };
+};
+
+interface KeyDownContext {
+  showSuggestions: boolean;
+  selectedIndex: number;
+  suggestions: string[];
+  inputValue: string;
+}
+
+const handleEnterKey = (ctx: KeyDownContext, addTag: (tag: string) => void): boolean => {
+  if (ctx.showSuggestions && ctx.selectedIndex >= 0) {
+    addTag(ctx.suggestions[ctx.selectedIndex]);
+  } else if (ctx.inputValue.trim()) {
+    addTag(ctx.inputValue);
+  }
+  return true;
+};
+
+const handleArrowKey = (
+  key: 'ArrowDown' | 'ArrowUp',
+  ctx: KeyDownContext,
+  setIndex: (index: number) => void,
+): boolean => {
+  if (ctx.showSuggestions && ctx.suggestions.length > 0) {
+    setIndex(handleNavigationKey(key, ctx.selectedIndex, ctx.suggestions.length));
+  }
+  return true;
+};
+
+interface KeyDownHandlerParams {
+  state: ReturnType<typeof useTagInputState>;
+  filteredSuggestions: string[];
+  tags: string[];
+  addTag: (tag: string) => void;
+  removeTag: (tag: string) => void;
+}
+
+const useKeyDownHandler = ({
+  state,
+  filteredSuggestions,
+  tags,
+  addTag,
+  removeTag,
+}: KeyDownHandlerParams) =>
+  useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      let shouldPrevent = false;
+      const ctx: KeyDownContext = {
+        showSuggestions: state.showSuggestions,
+        selectedIndex: state.selectedSuggestionIndex,
+        suggestions: filteredSuggestions,
+        inputValue: state.inputValue,
+      };
+
+      if (e.key === 'Enter') {
+        shouldPrevent = handleEnterKey(ctx, addTag);
+      } else if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        shouldPrevent = handleArrowKey(e.key, ctx, state.setSelectedSuggestionIndex);
+      } else if (e.key === 'Backspace' && state.inputValue === '' && tags.length > 0) {
+        removeTag(tags[tags.length - 1]);
+      } else if (e.key === 'Escape') {
+        state.setShowSuggestions(false);
+        state.setSelectedSuggestionIndex(-1);
+      }
+
+      if (shouldPrevent) e.preventDefault();
+    },
+    [addTag, removeTag, state, filteredSuggestions, tags],
+  );
+
+interface TagListProps {
+  tags: string[];
+  onRemove: (tag: string) => void;
+}
+
+const TagList: FC<TagListProps> = ({ tags, onRemove }) => (
+  <>
+    {tags.map((tag) => (
+      <TagBadge key={tag} onRemove={() => onRemove(tag)} tag={tag} />
+    ))}
+  </>
+);
+
+interface TagInputFieldProps {
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  value: string;
+  placeholder: string;
+  onChange: (value: string) => void;
+  onFocus: () => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+}
+
+const TagInputField: FC<TagInputFieldProps> = ({
+  inputRef,
+  value,
+  placeholder,
+  onChange,
+  onFocus,
+  onKeyDown,
+}) => (
+  <input
+    className="min-w-[80px] flex-1 border-none bg-transparent p-1 text-xs text-neutral-900 outline-none placeholder:text-neutral-500 dark:text-white dark:placeholder:text-neutral-400"
+    onChange={(e) => onChange(e.target.value)}
+    onFocus={onFocus}
+    onKeyDown={onKeyDown}
+    placeholder={placeholder}
+    ref={inputRef}
+    type="text"
+    value={value}
+  />
+);
+
+/** Hook for auto-focus on mount */
+const useAutoFocus = (
+  autoFocus: boolean,
+  inputRef: React.RefObject<HTMLInputElement | null>,
+): void => {
+  useEffect(() => {
+    if (autoFocus && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [autoFocus, inputRef]);
+};
+
+export const InlineTagInput: FC<InlineTagInputProps> = ({
+  tags,
+  onChange,
+  suggestions = [],
+  autoFocus = false,
+}) => {
+  const state = useTagInputState();
+  const filteredSuggestions = filterSuggestions(suggestions, state.inputValue, tags);
+  const { addTag, removeTag } = useTagActions({ tags, onChange, state });
+
+  const updateSuggestionState = useCallback(
+    (value: string) => {
+      state.setInputValue(value);
+      state.setShowSuggestions(value.length > 0 && filteredSuggestions.length > 0);
+      state.setSelectedSuggestionIndex(-1);
+    },
+    [state, filteredSuggestions.length],
+  );
+
+  const handleKeyDown = useKeyDownHandler({ state, filteredSuggestions, tags, addTag, removeTag });
+  const handleSuggestionSelect = (s: string) => {
+    addTag(s);
+    state.inputRef.current?.focus();
+  };
+
+  useClickOutside(state.inputRef, state.suggestionsRef, () => state.setShowSuggestions(false));
+  useAutoFocus(autoFocus, state.inputRef);
+
+  return (
+    <div className="relative">
+      <div className="flex flex-wrap items-center gap-1">
+        <TagList onRemove={removeTag} tags={tags} />
+        <TagInputField
+          inputRef={state.inputRef}
+          onChange={updateSuggestionState}
+          onFocus={() => updateSuggestionState(state.inputValue)}
+          onKeyDown={handleKeyDown}
+          placeholder={tags.length === 0 ? 'Add tags...' : ''}
+          value={state.inputValue}
+        />
+      </div>
+      {state.showSuggestions && filteredSuggestions.length > 0 && (
+        <SuggestionList
+          onSelect={handleSuggestionSelect}
+          selectedIndex={state.selectedSuggestionIndex}
+          suggestions={filteredSuggestions}
+          suggestionsRef={state.suggestionsRef}
+        />
+      )}
+    </div>
+  );
+};

--- a/packages/web-client/src/components/todo_table_cell.tsx
+++ b/packages/web-client/src/components/todo_table_cell.tsx
@@ -9,7 +9,7 @@ import { type FC, type ReactElement } from 'react';
 import { CONTEXT_DEFAULT } from '../constants';
 import { DueDatePopover } from './due_date_popover';
 import { FormattedMessage } from './formatted_message';
-import { TagDisplay } from './tag_display';
+import { TagsPopover } from './tags_popover';
 import { getColumnWidthClass } from './todo_table_helpers';
 
 interface TodoCellProps {
@@ -67,11 +67,7 @@ const DueCell: FC<{ todo: Todo; widthClass: string }> = ({ todo, widthClass }) =
 
 const TagsCell: FC<{ todo: Todo; widthClass: string }> = ({ todo, widthClass }) => (
   <td className={`px-2 py-1 ${widthClass}`}>
-    {todo.tags.length > 0 ? (
-      <TagDisplay maxTags={3} size="xs" tags={todo.tags} />
-    ) : (
-      <span className="text-xs text-neutral-400">-</span>
-    )}
+    <TagsPopover todo={todo} />
   </td>
 );
 


### PR DESCRIPTION
## Summary
Add inline editing of tags directly in the table view, similar to the existing due date inline editing.

## Changes
- New `TagsPopover` component for inline tag editing
- New `InlineTagInput` compact variant for use in popovers
- Updated `TagsCell` to use the new popover
- Added tests for TagsPopover

## Features
- Click tags in any row to open inline editor
- Autocomplete suggestions from existing tags
- Add/remove tags with keyboard support
- Auto-save on close (Escape or click outside)
- Shows "+N" indicator when more than 3 tags

Closes #401