### PR TITLE
fix: use createPortal for TodoFlyout to fix invalid HTML nesting

### DIFF
--- a/.changeset/fix-todo-flyout-html-nesting.md
+++ b/.changeset/fix-todo-flyout-html-nesting.md
@@ -1,0 +1,5 @@
+---
+"eddo-app": patch
+---
+
+Fix invalid HTML nesting error where TodoFlyout div was rendered inside tbody

--- a/packages/web-client/src/components/todo_flyout.tsx
+++ b/packages/web-client/src/components/todo_flyout.tsx
@@ -4,6 +4,7 @@
 import { type Todo } from '@eddo/core-client';
 import { Button, Drawer, DrawerHeader, DrawerItems } from 'flowbite-react';
 import { type FC } from 'react';
+import { createPortal } from 'react-dom';
 import { BiEdit, BiShow } from 'react-icons/bi';
 
 import { useTags } from '../hooks/use_tags';
@@ -220,7 +221,7 @@ export const TodoFlyout: FC<TodoFlyoutProps> = ({ onClose, show, todo }) => {
     return null;
   }
 
-  return (
+  return createPortal(
     <>
       <Drawer
         className="!w-[640px]"
@@ -248,7 +249,8 @@ export const TodoFlyout: FC<TodoFlyoutProps> = ({ onClose, show, todo }) => {
           onKeepEditing={state.handleKeepEditing}
         />
       )}
-    </>
+    </>,
+    document.body,
   );
 };
 


### PR DESCRIPTION
## Summary
Fix invalid HTML nesting error where TodoFlyout's `<div>` was rendered inside `<tbody>`.

## Changes
- Wrap TodoFlyout content in `createPortal(…, document.body)`
- Follows established pattern from PopoverMenu, TagsPopover, DueDatePopover

## Testing
- ✅ TypeScript check passes
- ✅ ESLint passes
- ✅ All 741 tests pass
- ✅ Manual verification: no console errors, flyout works correctly

Closes #408