### PR TITLE
fix: Time Tracked column shows duration within selected time range

### DIFF
--- a/.changeset/fix-time-tracked-column-range.md
+++ b/.changeset/fix-time-tracked-column-range.md
@@ -1,0 +1,5 @@
+---
+"eddo-app": patch
+---
+
+Fix Time Tracked table column to show duration within selected time range instead of only current date

--- a/packages/core-client/src/index.ts
+++ b/packages/core-client/src/index.ts
@@ -11,6 +11,7 @@ export {
   decodeJwtPayload,
   generateStableKey,
   getActiveDuration,
+  getActiveDurationInRange,
   getActiveRecordForActivities,
   getActiveRecordForTodos,
   getFormattedDuration,

--- a/packages/core-shared/src/index.ts
+++ b/packages/core-shared/src/index.ts
@@ -84,7 +84,7 @@ export {
 // Utils
 export { areTodosEqual } from './utils/are_todos_equal';
 export { generateStableKey } from './utils/generate_stable_key';
-export { getActiveDuration } from './utils/get_active_duration';
+export { getActiveDuration, getActiveDurationInRange } from './utils/get_active_duration';
 export { getActiveRecordForActivities } from './utils/get_active_record_for_activities';
 export { getActiveRecordForTodos } from './utils/get_active_record_for_todos';
 export {

--- a/packages/core-shared/src/utils/get_active_duration.test.ts
+++ b/packages/core-shared/src/utils/get_active_duration.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getActiveDuration } from './get_active_duration';
+import { getActiveDuration, getActiveDurationInRange } from './get_active_duration';
 
 describe('getActiveDuration', () => {
   it('gets 1m active duration of a single time logging entry', () => {
@@ -26,5 +26,76 @@ describe('getActiveDuration', () => {
         '2023-04-19T15:00:00.000Z': '2023-04-19T15:01:00.000Z',
       }),
     ).toBe(61000);
+  });
+});
+
+describe('getActiveDurationInRange', () => {
+  it('returns total duration when all entries are within range', () => {
+    expect(
+      getActiveDurationInRange(
+        {
+          '2023-04-18T15:00:00.000Z': '2023-04-18T15:01:00.000Z',
+          '2023-04-19T15:00:00.000Z': '2023-04-19T15:01:00.000Z',
+        },
+        '2023-04-18',
+        '2023-04-19',
+      ),
+    ).toBe(120000); // 2 minutes
+  });
+
+  it('excludes entries before the start date', () => {
+    expect(
+      getActiveDurationInRange(
+        {
+          '2023-04-17T15:00:00.000Z': '2023-04-17T15:01:00.000Z', // Before range
+          '2023-04-18T15:00:00.000Z': '2023-04-18T15:01:00.000Z', // In range
+        },
+        '2023-04-18',
+        '2023-04-20',
+      ),
+    ).toBe(60000); // 1 minute
+  });
+
+  it('excludes entries after the end date', () => {
+    expect(
+      getActiveDurationInRange(
+        {
+          '2023-04-18T15:00:00.000Z': '2023-04-18T15:01:00.000Z', // In range
+          '2023-04-21T15:00:00.000Z': '2023-04-21T15:01:00.000Z', // After range
+        },
+        '2023-04-18',
+        '2023-04-20',
+      ),
+    ).toBe(60000); // 1 minute
+  });
+
+  it('returns 0 when no entries are within range', () => {
+    expect(
+      getActiveDurationInRange(
+        {
+          '2023-04-15T15:00:00.000Z': '2023-04-15T15:01:00.000Z',
+          '2023-04-25T15:00:00.000Z': '2023-04-25T15:01:00.000Z',
+        },
+        '2023-04-18',
+        '2023-04-20',
+      ),
+    ).toBe(0);
+  });
+
+  it('returns 0 for empty active record', () => {
+    expect(getActiveDurationInRange({}, '2023-04-18', '2023-04-20')).toBe(0);
+  });
+
+  it('includes entries on the boundary dates', () => {
+    expect(
+      getActiveDurationInRange(
+        {
+          '2023-04-18T00:00:00.000Z': '2023-04-18T00:01:00.000Z', // Start boundary
+          '2023-04-20T23:59:00.000Z': '2023-04-20T23:59:30.000Z', // End boundary
+        },
+        '2023-04-18',
+        '2023-04-20',
+      ),
+    ).toBe(90000); // 1.5 minutes
   });
 });

--- a/packages/core-shared/src/utils/get_active_duration.ts
+++ b/packages/core-shared/src/utils/get_active_duration.ts
@@ -1,5 +1,11 @@
 import type { Todo } from '../types/todo';
 
+/**
+ * Calculates total duration from time tracking entries.
+ * @param active - Time tracking record with start timestamps as keys and end timestamps as values
+ * @param activeDate - Optional date string (yyyy-MM-dd) to filter entries by specific date
+ * @returns Total duration in milliseconds
+ */
 export function getActiveDuration(active: Todo['active'], activeDate?: string): number {
   return Object.entries(active).reduce((p, c) => {
     // TODO The 'split' is a CEST quick fix
@@ -10,5 +16,31 @@ export function getActiveDuration(active: Todo['active'], activeDate?: string): 
     }
 
     return p + (c[1] !== null ? new Date(c[1]) : new Date()).getTime() - new Date(c[0]).getTime();
+  }, 0);
+}
+
+/**
+ * Calculates total duration from time tracking entries within a date range.
+ * @param active - Time tracking record with start timestamps as keys and end timestamps as values
+ * @param startDate - Start of date range (yyyy-MM-dd)
+ * @param endDate - End of date range (yyyy-MM-dd)
+ * @returns Total duration in milliseconds
+ */
+export function getActiveDurationInRange(
+  active: Todo['active'],
+  startDate: string,
+  endDate: string,
+): number {
+  return Object.entries(active).reduce((total, [start, end]) => {
+    const entryDate = start.split('T')[0];
+
+    if (entryDate < startDate || entryDate > endDate) {
+      return total;
+    }
+
+    const startTime = new Date(start).getTime();
+    const endTime = end !== null ? new Date(end).getTime() : Date.now();
+
+    return total + (endTime - startTime);
   }, 0);
 }

--- a/packages/web-client/src/components/todo_table.tsx
+++ b/packages/web-client/src/components/todo_table.tsx
@@ -2,7 +2,6 @@
  * Table view for todos grouped by context
  */
 import { type Activity, type DatabaseError, type Todo } from '@eddo/core-client';
-import { format } from 'date-fns';
 import { Spinner } from 'flowbite-react';
 import { type FC, useMemo } from 'react';
 
@@ -14,7 +13,7 @@ import { EmptyState } from './empty_state';
 import { FormattedMessage } from './formatted_message';
 import type { CompletionStatus } from './status_filter';
 import type { TimeRange } from './time_range_filter';
-import { calculateDateRange } from './todo_board_helpers';
+import { calculateDateRange, type DateRange } from './todo_board_helpers';
 import { useDbInitialization, useTodoBoardData } from './todo_board_state';
 import {
   calculateDurationByContext,
@@ -41,6 +40,7 @@ interface TableDataResult {
   displayError: DatabaseError | null;
   hasNoTodos: boolean;
   hasActiveFilters: boolean;
+  dateRange: DateRange;
 }
 
 const useTableData = (
@@ -88,6 +88,7 @@ const useTableData = (
     displayError: error || (boardData.queryError as DatabaseError | null),
     hasNoTodos,
     hasActiveFilters,
+    dateRange,
   };
 };
 
@@ -133,7 +134,7 @@ export const TodoTable: FC<TodoTableProps> = (props) => {
         />
       ) : (
         <TodoTableContent
-          currentDate={props.currentDate}
+          dateRange={data.dateRange}
           durationByContext={data.durationByContext}
           groupedByContext={data.groupedByContext}
           selectedColumns={props.selectedColumns}
@@ -160,7 +161,7 @@ interface TodoTableContentProps {
   durationByContext: Record<string, string>;
   selectedColumns: string[];
   timeTrackingActive: string[];
-  currentDate: Date;
+  dateRange: DateRange;
 }
 
 const TodoTableContent: FC<TodoTableContentProps> = ({
@@ -168,14 +169,14 @@ const TodoTableContent: FC<TodoTableContentProps> = ({
   durationByContext,
   selectedColumns,
   timeTrackingActive,
-  currentDate,
+  dateRange,
 }) => (
   <div className="overflow-x-auto py-2">
     {groupedByContext.map(([context, contextTodos]) => (
       <ContextGroup
         context={context}
         contextTodos={contextTodos}
-        currentDate={currentDate}
+        dateRange={dateRange}
         durationByContext={durationByContext}
         key={context}
         selectedColumns={selectedColumns}
@@ -191,7 +192,7 @@ interface ContextGroupProps {
   durationByContext: Record<string, string>;
   selectedColumns: string[];
   timeTrackingActive: string[];
-  currentDate: Date;
+  dateRange: DateRange;
 }
 
 const ContextGroup: FC<ContextGroupProps> = ({
@@ -200,7 +201,7 @@ const ContextGroup: FC<ContextGroupProps> = ({
   durationByContext,
   selectedColumns,
   timeTrackingActive,
-  currentDate,
+  dateRange,
 }) => (
   <div className="mb-4">
     <ContextHeader context={context} duration={durationByContext[context]} />
@@ -210,7 +211,7 @@ const ContextGroup: FC<ContextGroupProps> = ({
         <tbody className="divide-y divide-neutral-200 bg-white dark:divide-neutral-700 dark:bg-neutral-800">
           {contextTodos.map((todo) => (
             <TodoRow
-              activeDate={format(currentDate, 'yyyy-MM-dd')}
+              dateRange={dateRange}
               key={`${todo._id}-${todo._rev}`}
               selectedColumns={selectedColumns}
               timeTrackingActive={timeTrackingActive.length > 0}


### PR DESCRIPTION
Fixes #410

## Summary
The Time Tracked table column now correctly shows duration within the selected time range (e.g., 'This Week', 'This Month') instead of only the current date.

## Changes
- Added `getActiveDurationInRange()` function to core-shared for filtering time entries by date range
- Updated `TodoRow` to receive full date range instead of single date
- Added 6 unit tests for the new function

## Root Cause
The table already calculated `dateRange` from the time filter, but only passed a single formatted date to rows. The fix passes the full range through the component hierarchy.