### PR TITLE
feat(web-client): add client-side RUM with OpenTelemetry browser SDK

### DIFF
--- a/.changeset/add-client-side-rum.md
+++ b/.changeset/add-client-side-rum.md
@@ -1,0 +1,5 @@
+---
+"eddo-app": minor
+---
+
+Add client-side Real User Monitoring (RUM) with OpenTelemetry browser SDK

--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ PRINTER_PORT=9100
 PRINTER_SCHEDULE_TIME=07:00
 
 # ============================================
-# OpenTelemetry Configuration
+# OpenTelemetry Configuration (Server-side)
 # ============================================
 
 # Disable OpenTelemetry (set to 'true' to disable tracing/metrics export)
@@ -52,6 +52,32 @@ PRINTER_SCHEDULE_TIME=07:00
 # OTLP endpoint (collector running locally via Docker)
 # Default: http://localhost:4318
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+
+# API key for OTLP endpoint (optional, injected by telemetry proxy for browser RUM)
+# OTEL_API_KEY=your_api_key_here
+
+# ============================================
+# OpenTelemetry Configuration (Client-side/Browser RUM)
+# ============================================
+# These VITE_ prefixed vars are exposed to the browser at build time
+
+# Enable/disable browser telemetry (default: true)
+# VITE_OTEL_ENABLED=true
+
+# Service name for browser traces (default: eddo-web-client)
+# VITE_OTEL_SERVICE_NAME=eddo-web-client
+
+# Service version (default: 0.3.0)
+# VITE_OTEL_SERVICE_VERSION=0.3.0
+
+# Environment name (default: development in dev, production in prod)
+# VITE_OTEL_ENVIRONMENT=development
+
+# Traces endpoint (default: /api/telemetry/v1/traces - proxied through web-api)
+# VITE_OTEL_TRACES_ENDPOINT=/api/telemetry/v1/traces
+
+# Log level for OTEL diagnostics (error, warn, info, debug, verbose)
+# VITE_OTEL_LOG_LEVEL=warn
 
 # ============================================
 # EDOT Collector Configuration (for docker-compose.otel.yml)

--- a/packages/core-server/src/config/env.ts
+++ b/packages/core-server/src/config/env.ts
@@ -48,6 +48,10 @@ export const envSchema = z.object({
   GOOGLE_CLIENT_ID: z.string().optional(),
   GOOGLE_CLIENT_SECRET: z.string().optional(),
   GOOGLE_REDIRECT_URI: z.string().default('http://localhost:3000/api/email/oauth/callback'),
+
+  // OpenTelemetry Configuration (for RUM proxy)
+  OTEL_EXPORTER_OTLP_ENDPOINT: z.string().default('http://localhost:4318'),
+  OTEL_API_KEY: z.string().optional(),
 });
 
 /**

--- a/packages/web-api/src/index.ts
+++ b/packages/web-api/src/index.ts
@@ -25,6 +25,7 @@ import { authRoutes } from './routes/auth';
 import { dbProxyRoutes } from './routes/db-proxy';
 import { emailRoutes } from './routes/email';
 import { rssRoutes } from './routes/rss';
+import { telemetryRoutes } from './routes/telemetry';
 import { userRoutes } from './routes/users';
 import { createRssSyncScheduler } from './rss/sync-scheduler';
 import { logger } from './utils/logger';
@@ -57,6 +58,9 @@ app.route('/auth', authRoutes);
 
 // Email OAuth callback (no JWT required - Google redirects here)
 app.route('/api/email', emailRoutes);
+
+// Telemetry proxy (no JWT required - browser sends traces before auth)
+app.route('/api/telemetry', telemetryRoutes);
 
 // Protected API routes (JWT required)
 // Custom middleware that supports both header and query param tokens (for SSE/EventSource)

--- a/packages/web-api/src/routes/telemetry.ts
+++ b/packages/web-api/src/routes/telemetry.ts
@@ -1,0 +1,127 @@
+/**
+ * Telemetry Proxy Routes
+ *
+ * Proxies browser telemetry data to OTEL Collector.
+ * This avoids exposing OTEL API keys in the browser and handles CORS.
+ *
+ * @see https://www.elastic.co/docs/solutions/observability/applications/otel-rum
+ */
+
+import { createEnv } from '@eddo/core-server';
+import { Hono } from 'hono';
+
+import { logger } from '../utils/logger';
+
+const telemetryApp = new Hono();
+
+/** Gets OTEL collector endpoint from environment */
+function getOtelEndpoint(): string {
+  const env = createEnv();
+  return env.OTEL_EXPORTER_OTLP_ENDPOINT;
+}
+
+/** Gets optional OTEL API key from environment */
+function getOtelApiKey(): string | undefined {
+  const env = createEnv();
+  return env.OTEL_API_KEY;
+}
+
+/** Builds headers for OTEL collector request */
+function buildOtelHeaders(contentType: string | undefined): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': contentType ?? 'application/json',
+  };
+
+  const apiKey = getOtelApiKey();
+  if (apiKey) {
+    headers['Authorization'] = `ApiKey ${apiKey}`;
+  }
+
+  return headers;
+}
+
+/** Proxies request to OTEL collector */
+async function proxyToOtel(
+  endpoint: string,
+  body: string,
+  headers: Record<string, string>,
+): Promise<Response> {
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers,
+    body,
+  });
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: {
+      'Content-Type': response.headers.get('Content-Type') ?? 'application/json',
+    },
+  });
+}
+
+/**
+ * POST /api/telemetry/v1/traces
+ * Proxies trace data to OTEL Collector
+ */
+telemetryApp.post('/v1/traces', async (c) => {
+  const otelEndpoint = getOtelEndpoint();
+  const tracesUrl = `${otelEndpoint}/v1/traces`;
+
+  try {
+    const body = await c.req.text();
+    const headers = buildOtelHeaders(c.req.header('Content-Type'));
+
+    logger.debug({ tracesUrl }, 'Proxying traces to OTEL collector');
+
+    return await proxyToOtel(tracesUrl, body, headers);
+  } catch (error) {
+    logger.error({ error, tracesUrl }, 'Failed to proxy traces to OTEL collector');
+    return c.json({ error: 'Failed to send telemetry' }, 502);
+  }
+});
+
+/**
+ * POST /api/telemetry/v1/metrics
+ * Proxies metrics data to OTEL Collector
+ */
+telemetryApp.post('/v1/metrics', async (c) => {
+  const otelEndpoint = getOtelEndpoint();
+  const metricsUrl = `${otelEndpoint}/v1/metrics`;
+
+  try {
+    const body = await c.req.text();
+    const headers = buildOtelHeaders(c.req.header('Content-Type'));
+
+    logger.debug({ metricsUrl }, 'Proxying metrics to OTEL collector');
+
+    return await proxyToOtel(metricsUrl, body, headers);
+  } catch (error) {
+    logger.error({ error, metricsUrl }, 'Failed to proxy metrics to OTEL collector');
+    return c.json({ error: 'Failed to send telemetry' }, 502);
+  }
+});
+
+/**
+ * POST /api/telemetry/v1/logs
+ * Proxies log data to OTEL Collector
+ */
+telemetryApp.post('/v1/logs', async (c) => {
+  const otelEndpoint = getOtelEndpoint();
+  const logsUrl = `${otelEndpoint}/v1/logs`;
+
+  try {
+    const body = await c.req.text();
+    const headers = buildOtelHeaders(c.req.header('Content-Type'));
+
+    logger.debug({ logsUrl }, 'Proxying logs to OTEL collector');
+
+    return await proxyToOtel(logsUrl, body, headers);
+  } catch (error) {
+    logger.error({ error, logsUrl }, 'Failed to proxy logs to OTEL collector');
+    return c.json({ error: 'Failed to send telemetry' }, 502);
+  }
+});
+
+export { telemetryApp as telemetryRoutes };

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -30,6 +30,7 @@
     "@opentelemetry/context-zone": "^2.2.0",
     "@opentelemetry/core": "^2.2.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.208.0",
+    "@opentelemetry/instrumentation": "^0.208.0",
     "@opentelemetry/instrumentation-document-load": "^0.54.0",
     "@opentelemetry/instrumentation-fetch": "^0.208.0",
     "@opentelemetry/opentelemetry-browser-detector": "^0.208.0",

--- a/packages/web-client/src/client.tsx
+++ b/packages/web-client/src/client.tsx
@@ -6,6 +6,10 @@ import { ThemeInit } from '../../../.flowbite-react/init';
 import { Eddo } from './eddo';
 import './eddo.css';
 import { customFlowbiteTheme } from './flowbite_theme';
+import { initTelemetry } from './telemetry';
+
+// Initialize OpenTelemetry before React renders to capture page load metrics
+initTelemetry();
 
 // Ensure the root element exists
 const rootElement = document.getElementById('root');

--- a/packages/web-client/src/hooks/use_auth.tsx
+++ b/packages/web-client/src/hooks/use_auth.tsx
@@ -1,6 +1,8 @@
 import { isTokenExpired } from '@eddo/core-client';
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from 'react';
 
+import { clearTelemetryUser, setTelemetryUser } from '../telemetry';
+
 interface AuthToken {
   token: string;
   username: string;
@@ -133,6 +135,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const logout = useCallback(() => {
     setAuthToken(null);
     localStorage.removeItem('authToken');
+    clearTelemetryUser();
   }, []);
   const checkTokenExpiration = useCallback(() => {
     if (authToken && isTokenExpired(authToken.token)) {
@@ -146,6 +149,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     setAuthToken(loadStoredToken());
   }, []);
+
+  // Update telemetry user context when auth state changes
+  useEffect(() => {
+    if (authToken?.username) {
+      setTelemetryUser(authToken.username);
+    } else {
+      clearTelemetryUser();
+    }
+  }, [authToken?.username]);
+
   useTokenExpirationCheck(authToken, checkTokenExpiration);
 
   const value: AuthContextValue = {

--- a/packages/web-client/src/telemetry/config.ts
+++ b/packages/web-client/src/telemetry/config.ts
@@ -1,0 +1,41 @@
+/**
+ * OpenTelemetry configuration for browser RUM.
+ *
+ * Environment variables are injected by Vite at build time.
+ * Prefix with VITE_ to expose to client code.
+ */
+
+/** Telemetry configuration interface */
+export interface TelemetryConfig {
+  /** Service name for traces */
+  serviceName: string;
+  /** Service version */
+  serviceVersion: string;
+  /** Deployment environment (dev, staging, prod) */
+  environment: string;
+  /** OTLP endpoint URL for traces */
+  tracesEndpoint: string;
+  /** Whether telemetry is enabled */
+  enabled: boolean;
+  /** Log level for OTEL diagnostics */
+  logLevel: 'error' | 'warn' | 'info' | 'debug' | 'verbose';
+}
+
+/**
+ * Creates telemetry configuration from environment variables.
+ * @returns Telemetry configuration
+ */
+export function createTelemetryConfig(): TelemetryConfig {
+  const isProduction = import.meta.env.PROD;
+
+  return {
+    serviceName: import.meta.env.VITE_OTEL_SERVICE_NAME ?? 'eddo-web-client',
+    serviceVersion: import.meta.env.VITE_OTEL_SERVICE_VERSION ?? '0.3.0',
+    environment:
+      import.meta.env.VITE_OTEL_ENVIRONMENT ?? (isProduction ? 'production' : 'development'),
+    // Default to proxied endpoint through web-api to avoid CORS and API key exposure
+    tracesEndpoint: import.meta.env.VITE_OTEL_TRACES_ENDPOINT ?? '/api/telemetry/v1/traces',
+    enabled: import.meta.env.VITE_OTEL_ENABLED !== 'false',
+    logLevel: (import.meta.env.VITE_OTEL_LOG_LEVEL as TelemetryConfig['logLevel']) ?? 'warn',
+  };
+}

--- a/packages/web-client/src/telemetry/hooks.ts
+++ b/packages/web-client/src/telemetry/hooks.ts
@@ -1,0 +1,87 @@
+/**
+ * Telemetry React Hooks
+ *
+ * Provides hooks for instrumenting React components and user actions.
+ */
+
+import type { Attributes } from '@opentelemetry/api';
+import { SpanStatusCode } from '@opentelemetry/api';
+import { useCallback } from 'react';
+
+import { getTracer } from './tracer';
+import { getTelemetryUser } from './user_context';
+
+/**
+ * Hook that returns a function to wrap async actions with telemetry spans.
+ *
+ * @example
+ * ```typescript
+ * const withTelemetry = useTelemetryAction();
+ *
+ * const handleSave = () => withTelemetry(
+ *   'todo.save',
+ *   { 'todo.id': todoId },
+ *   async () => await saveTodo(todo)
+ * );
+ * ```
+ */
+export function useTelemetryAction() {
+  return useCallback(
+    <T>(name: string, attributes: Attributes, fn: () => Promise<T>): Promise<T> => {
+      const tracer = getTracer();
+      const user = getTelemetryUser();
+
+      const allAttributes: Attributes = { ...attributes };
+      if (user) {
+        allAttributes['user.id'] = user.userId;
+        allAttributes['user.name'] = user.username;
+      }
+
+      return tracer.startActiveSpan(name, { attributes: allAttributes }, async (span) => {
+        try {
+          const result = await fn();
+          span.setStatus({ code: SpanStatusCode.OK });
+          return result;
+        } catch (error) {
+          span.recordException(error instanceof Error ? error : new Error(String(error)));
+          span.setStatus({ code: SpanStatusCode.ERROR });
+          throw error;
+        } finally {
+          span.end();
+        }
+      });
+    },
+    [],
+  );
+}
+
+/**
+ * Hook that returns a function to record instant UI events as spans.
+ * Use for button clicks, navigation, and other synchronous actions.
+ *
+ * @example
+ * ```typescript
+ * const recordAction = useRecordAction();
+ *
+ * const handleClick = () => {
+ *   recordAction('button.click', { 'button.name': 'save' });
+ *   // ... do stuff
+ * };
+ * ```
+ */
+export function useRecordAction() {
+  return useCallback((name: string, attributes: Attributes = {}) => {
+    const tracer = getTracer();
+    const user = getTelemetryUser();
+
+    const allAttributes: Attributes = { ...attributes };
+    if (user) {
+      allAttributes['user.id'] = user.userId;
+      allAttributes['user.name'] = user.username;
+    }
+
+    const span = tracer.startSpan(name, { attributes: allAttributes });
+    span.setStatus({ code: SpanStatusCode.OK });
+    span.end();
+  }, []);
+}

--- a/packages/web-client/src/telemetry/index.ts
+++ b/packages/web-client/src/telemetry/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Browser Telemetry Module
+ *
+ * OpenTelemetry-based Real User Monitoring (RUM) for the Eddo web client.
+ * Tracks page loads, fetch requests, and custom application spans.
+ *
+ * @example
+ * ```typescript
+ * // Initialize at app startup (before React renders)
+ * import { initTelemetry } from './telemetry';
+ * initTelemetry();
+ *
+ * // Set user context after login
+ * import { setTelemetryUser } from './telemetry';
+ * setTelemetryUser(username);
+ *
+ * // Manual instrumentation
+ * import { withSpan } from './telemetry';
+ * await withSpan('custom-operation', { 'custom.attr': 'value' }, async (span) => {
+ *   // ... do work
+ * });
+ * ```
+ */
+
+export { createTelemetryConfig } from './config';
+export type { TelemetryConfig } from './config';
+export { useRecordAction, useTelemetryAction } from './hooks';
+export { recordSyncEvent, withSpan } from './spans';
+export type { SyncStatus } from './spans';
+export { getTracer, initTelemetry, shutdownTelemetry } from './tracer';
+export { clearTelemetryUser, getTelemetryUser, setTelemetryUser } from './user_context';

--- a/packages/web-client/src/telemetry/spans.ts
+++ b/packages/web-client/src/telemetry/spans.ts
@@ -1,0 +1,91 @@
+/**
+ * Custom Span Helpers for Telemetry
+ *
+ * Provides convenience functions for creating spans around common operations.
+ */
+
+import type { Attributes, Span } from '@opentelemetry/api';
+import { SpanStatusCode } from '@opentelemetry/api';
+
+import { getTracer } from './tracer';
+import { addUserToActiveSpan, getTelemetryUser } from './user_context';
+
+/**
+ * Executes a function within a custom span.
+ *
+ * Automatically handles:
+ * - Span creation with user context
+ * - Error recording
+ * - Span ending
+ *
+ * @param name - Span name
+ * @param attributes - Span attributes
+ * @param fn - Function to execute
+ * @returns Result of the function
+ */
+export function withSpan<T>(name: string, attributes: Attributes, fn: (span: Span) => T): T {
+  const tracer = getTracer();
+  const user = getTelemetryUser();
+
+  // Add user attributes if available
+  const allAttributes: Attributes = { ...attributes };
+  if (user) {
+    allAttributes['user.id'] = user.userId;
+    allAttributes['user.name'] = user.username;
+  }
+
+  return tracer.startActiveSpan(name, { attributes: allAttributes }, (span) => {
+    try {
+      const result = fn(span);
+
+      if (result instanceof Promise) {
+        return result
+          .then((value: unknown) => {
+            span.setStatus({ code: SpanStatusCode.OK });
+            return value;
+          })
+          .catch((error: unknown) => {
+            span.recordException(error instanceof Error ? error : new Error(String(error)));
+            span.setStatus({ code: SpanStatusCode.ERROR });
+            throw error;
+          })
+          .finally(() => {
+            span.end();
+          }) as T;
+      }
+
+      span.setStatus({ code: SpanStatusCode.OK });
+      span.end();
+      return result;
+    } catch (error) {
+      span.recordException(error instanceof Error ? error : new Error(String(error)));
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      span.end();
+      throw error;
+    }
+  });
+}
+
+/** PouchDB sync status for telemetry */
+export type SyncStatus = 'started' | 'active' | 'paused' | 'complete' | 'error' | 'cancelled';
+
+/**
+ * Records a PouchDB sync event as a span event on the active span.
+ * @param status - Sync status
+ * @param details - Optional details
+ */
+export function recordSyncEvent(status: SyncStatus, details?: Record<string, unknown>): void {
+  addUserToActiveSpan();
+
+  const tracer = getTracer();
+  const span = tracer.startSpan(`pouchdb.sync.${status}`, {
+    attributes: {
+      'db.system': 'pouchdb',
+      'db.operation': 'sync',
+      'sync.status': status,
+      ...details,
+    },
+  });
+
+  span.end();
+}

--- a/packages/web-client/src/telemetry/tracer.ts
+++ b/packages/web-client/src/telemetry/tracer.ts
@@ -1,0 +1,149 @@
+/**
+ * OpenTelemetry Browser Tracer
+ *
+ * Provides distributed tracing for the web client using OpenTelemetry SDK.
+ * Sends traces to EDOT Collector via a proxy endpoint to avoid exposing API keys.
+ *
+ * @see https://www.elastic.co/docs/solutions/observability/applications/otel-rum
+ * @see https://opentelemetry.io/docs/languages/js/getting-started/browser/
+ */
+
+import type { Resource } from '@opentelemetry/resources';
+
+import { diag, DiagConsoleLogger, DiagLogLevel, trace } from '@opentelemetry/api';
+import { ZoneContextManager } from '@opentelemetry/context-zone';
+import {
+  CompositePropagator,
+  W3CBaggagePropagator,
+  W3CTraceContextPropagator,
+} from '@opentelemetry/core';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-document-load';
+import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
+import { browserDetector } from '@opentelemetry/opentelemetry-browser-detector';
+import { detectResources, resourceFromAttributes } from '@opentelemetry/resources';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+
+import type { TelemetryConfig } from './config';
+import { createTelemetryConfig } from './config';
+
+/** Maps config log level to OTEL DiagLogLevel */
+function getDiagLogLevel(level: TelemetryConfig['logLevel']): DiagLogLevel {
+  const levels: Record<TelemetryConfig['logLevel'], DiagLogLevel> = {
+    error: DiagLogLevel.ERROR,
+    warn: DiagLogLevel.WARN,
+    info: DiagLogLevel.INFO,
+    debug: DiagLogLevel.DEBUG,
+    verbose: DiagLogLevel.VERBOSE,
+  };
+  return levels[level] ?? DiagLogLevel.WARN;
+}
+
+/** Creates resource with service metadata and browser detection */
+function createResource(config: TelemetryConfig): Resource {
+  const detectedResources = detectResources({ detectors: [browserDetector] });
+  const baseResource = resourceFromAttributes({
+    'service.name': config.serviceName,
+    'service.version': config.serviceVersion,
+    'deployment.environment.name': config.environment,
+  });
+  return baseResource.merge(detectedResources);
+}
+
+/** Creates and configures tracer provider */
+function createTracerProvider(config: TelemetryConfig, resource: Resource): WebTracerProvider {
+  const exporter = new OTLPTraceExporter({ url: config.tracesEndpoint });
+  const provider = new WebTracerProvider({
+    resource,
+    spanProcessors: [new BatchSpanProcessor(exporter)],
+  });
+
+  provider.register({
+    contextManager: new ZoneContextManager(),
+    propagator: new CompositePropagator({
+      propagators: [new W3CBaggagePropagator(), new W3CTraceContextPropagator()],
+    }),
+  });
+
+  return provider;
+}
+
+/** Registers automatic browser instrumentations */
+function setupInstrumentations(): void {
+  registerInstrumentations({
+    instrumentations: [
+      new DocumentLoadInstrumentation({
+        ignoreNetworkEvents: false,
+        ignorePerformancePaintEvents: false,
+      }),
+      new FetchInstrumentation({
+        propagateTraceHeaderCorsUrls: [/^\/api\//, new RegExp(`^${window.location.origin}`)],
+        clearTimingResources: true,
+      }),
+    ],
+  });
+}
+
+/** Tracer provider instance */
+let tracerProvider: WebTracerProvider | null = null;
+
+/** Initialization state */
+let initialized = false;
+
+/**
+ * Initializes OpenTelemetry tracing for the browser.
+ *
+ * Must be called once at application startup, before React renders.
+ * Safe to call multiple times - subsequent calls are no-ops.
+ */
+export function initTelemetry(): void {
+  if (initialized) {
+    return;
+  }
+
+  const config = createTelemetryConfig();
+
+  if (!config.enabled) {
+    console.info('[Telemetry] Disabled via configuration');
+    initialized = true;
+    return;
+  }
+
+  diag.setLogger(new DiagConsoleLogger(), getDiagLogLevel(config.logLevel));
+
+  const resource = createResource(config);
+  tracerProvider = createTracerProvider(config, resource);
+  setupInstrumentations();
+
+  diag.info('[Telemetry] Initialized', {
+    serviceName: config.serviceName,
+    environment: config.environment,
+    tracesEndpoint: config.tracesEndpoint,
+  });
+
+  initialized = true;
+}
+
+/**
+ * Gets a tracer instance for manual instrumentation.
+ * @param name - Tracer name (defaults to service name)
+ * @returns Tracer instance
+ */
+export function getTracer(name?: string) {
+  const config = createTelemetryConfig();
+  return trace.getTracer(name ?? config.serviceName);
+}
+
+/**
+ * Shuts down telemetry and flushes pending spans.
+ * Call during application cleanup if needed.
+ */
+export async function shutdownTelemetry(): Promise<void> {
+  if (tracerProvider) {
+    await tracerProvider.shutdown();
+    tracerProvider = null;
+    initialized = false;
+  }
+}

--- a/packages/web-client/src/telemetry/user_context.ts
+++ b/packages/web-client/src/telemetry/user_context.ts
@@ -1,0 +1,58 @@
+/**
+ * User Context for Telemetry
+ *
+ * Sets user attributes on spans for better trace correlation in Kibana.
+ * Called after successful authentication.
+ */
+
+import { trace } from '@opentelemetry/api';
+
+/** Current user context for telemetry */
+interface UserContext {
+  userId: string;
+  username: string;
+}
+
+let currentUserContext: UserContext | null = null;
+
+/**
+ * Sets user context for all subsequent spans.
+ * Call after successful login.
+ * @param username - Authenticated username
+ */
+export function setTelemetryUser(username: string): void {
+  currentUserContext = {
+    userId: username, // Use username as ID since we don't have separate user IDs
+    username,
+  };
+}
+
+/**
+ * Clears user context.
+ * Call on logout.
+ */
+export function clearTelemetryUser(): void {
+  currentUserContext = null;
+}
+
+/**
+ * Gets current user context.
+ * @returns User context or null if not authenticated
+ */
+export function getTelemetryUser(): UserContext | null {
+  return currentUserContext;
+}
+
+/**
+ * Adds user attributes to the current active span.
+ * Safe to call even if no active span exists.
+ */
+export function addUserToActiveSpan(): void {
+  if (!currentUserContext) return;
+
+  const span = trace.getActiveSpan();
+  if (span) {
+    span.setAttribute('user.id', currentUserContext.userId);
+    span.setAttribute('user.name', currentUserContext.username);
+  }
+}

--- a/packages/web-client/src/vite-env.d.ts
+++ b/packages/web-client/src/vite-env.d.ts
@@ -2,6 +2,18 @@
 
 interface ImportMetaEnv {
   readonly NODE_ENV: string;
+  /** OpenTelemetry service name */
+  readonly VITE_OTEL_SERVICE_NAME?: string;
+  /** OpenTelemetry service version */
+  readonly VITE_OTEL_SERVICE_VERSION?: string;
+  /** OpenTelemetry deployment environment */
+  readonly VITE_OTEL_ENVIRONMENT?: string;
+  /** OpenTelemetry traces endpoint URL */
+  readonly VITE_OTEL_TRACES_ENDPOINT?: string;
+  /** Enable/disable OpenTelemetry (default: true) */
+  readonly VITE_OTEL_ENABLED?: string;
+  /** OpenTelemetry log level */
+  readonly VITE_OTEL_LOG_LEVEL?: 'error' | 'warn' | 'info' | 'debug' | 'verbose';
 }
 
 interface ImportMeta {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -670,6 +670,9 @@ importers:
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.208.0
         version: 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation':
+        specifier: ^0.208.0
+        version: 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation-document-load':
         specifier: ^0.54.0
         version: 0.54.0(@opentelemetry/api@1.9.0)


### PR DESCRIPTION
## Summary

Add Real User Monitoring (RUM) to web-client using OpenTelemetry browser SDK.

## Changes

- **Telemetry module** (`packages/web-client/src/telemetry/`)
  - `config.ts` - Configuration from VITE_OTEL_* env vars
  - `tracer.ts` - WebTracerProvider with OTLP exporter
  - `spans.ts` - Custom span helpers for sync events
  - `user_context.ts` - User context for trace correlation
  - `hooks.ts` - React hooks (`useTelemetryAction`, `useRecordAction`)

- **OTLP proxy** (`packages/web-api/src/routes/telemetry.ts`)
  - Proxies browser traces to OTEL collector
  - Injects API key server-side (not exposed to browser)

- **Instrumented operations**
  - PouchDB sync events (started, active, paused, complete, error)
  - Todo CRUD (create, update, save, delete, complete, uncomplete)
  - Time tracking (start, stop)
  - User context on auth changes

- **Documentation**
  - Updated CLAUDE.md with RUM architecture and ES|QL queries
  - Added env vars to .env.example

## Testing

- All 754 unit tests pass
- Verified traces appear in Kibana Discover
- Screenshot confirmation of `todo.update` span with attributes
