### PR TITLE
fix(web-client): sort table columns by canonical order

### DIFF
--- a/.changeset/fix-table-column-order.md
+++ b/.changeset/fix-table-column-order.md
@@ -1,0 +1,5 @@
+---
+"eddo-app": patch
+---
+
+Fix table column order in gear icon popover - columns now always display in canonical order regardless of stored preferences

--- a/packages/web-client/src/components/view_settings_popover.tsx
+++ b/packages/web-client/src/components/view_settings_popover.tsx
@@ -9,7 +9,11 @@ import { HiOutlineCog } from 'react-icons/hi';
 import { MdTableChart, MdViewKanban } from 'react-icons/md';
 
 import { useFloatingPosition } from '../hooks/use_floating_position';
-import type { ViewMode } from '../hooks/use_view_preferences';
+import {
+  AVAILABLE_COLUMNS,
+  sortColumnsByCanonicalOrder,
+  type ViewMode,
+} from '../hooks/use_view_preferences';
 import { TRANSITION_FAST } from '../styles/interactive';
 
 interface ViewSettingsPopoverProps {
@@ -22,20 +26,6 @@ interface ViewSettingsPopoverProps {
 
 const POPOVER_STYLES =
   'z-50 w-64 rounded-lg border border-neutral-200 bg-white p-3 shadow-lg dark:border-neutral-600 dark:bg-neutral-800';
-
-const AVAILABLE_COLUMNS = [
-  { id: 'title', label: 'Title' },
-  { id: 'subtasks', label: 'Subtasks' },
-  { id: 'context', label: 'Context' },
-  { id: 'due', label: 'Due Date' },
-  { id: 'tags', label: 'Tags' },
-  { id: 'timeTracked', label: 'Time Tracked' },
-  { id: 'status', label: 'Status' },
-  { id: 'completed', label: 'Completed Date' },
-  { id: 'repeat', label: 'Repeat' },
-  { id: 'link', label: 'Link' },
-  { id: 'description', label: 'Description' },
-];
 
 /** Hook for popover dismiss behavior (click outside, escape key) */
 const usePopoverDismiss = (
@@ -261,9 +251,11 @@ export const ViewSettingsPopover: FC<ViewSettingsPopoverProps> = ({
   const handleToggleColumn = (columnId: string) => {
     const isSelected = tableColumns.includes(columnId);
     if (isSelected && tableColumns.length === 1) return;
-    const newColumns = isSelected
+    const updatedColumns = isSelected
       ? tableColumns.filter((id) => id !== columnId)
       : [...tableColumns, columnId];
+    // Sort to maintain canonical order when columns are toggled
+    const newColumns = sortColumnsByCanonicalOrder(updatedColumns);
     onTableColumnsChange(newColumns);
   };
 

--- a/packages/web-client/src/hooks/use_view_preferences.ts
+++ b/packages/web-client/src/hooks/use_view_preferences.ts
@@ -4,7 +4,58 @@ import { useProfile } from './use_profile';
 
 export type ViewMode = 'kanban' | 'table';
 
-export const DEFAULT_TABLE_COLUMNS = ['status', 'title', 'subtasks', 'due', 'tags', 'timeTracked'];
+/** Column definition with id and display label */
+export interface ColumnDefinition {
+  id: string;
+  label: string;
+}
+
+/** Canonical list of all available columns in display order */
+export const AVAILABLE_COLUMNS: readonly ColumnDefinition[] = [
+  { id: 'status', label: 'Status' },
+  { id: 'title', label: 'Title' },
+  { id: 'due', label: 'Due Date' },
+  { id: 'tags', label: 'Tags' },
+  { id: 'timeTracked', label: 'Time Tracked' },
+  { id: 'subtasks', label: 'Subtasks' },
+  { id: 'context', label: 'Context' },
+  { id: 'completed', label: 'Completed Date' },
+  { id: 'repeat', label: 'Repeat' },
+  { id: 'link', label: 'Link' },
+  { id: 'description', label: 'Description' },
+] as const;
+
+/** Column IDs in canonical order for quick lookup */
+const CANONICAL_COLUMN_ORDER = AVAILABLE_COLUMNS.map((col) => col.id);
+
+/**
+ * Sorts column IDs to match canonical order defined in AVAILABLE_COLUMNS.
+ * Unknown columns are appended at the end in their original order.
+ * @param columns - Array of column IDs to sort
+ * @returns New array sorted by canonical order
+ */
+export function sortColumnsByCanonicalOrder(columns: readonly string[]): string[] {
+  const columnSet = new Set(columns);
+  const sorted: string[] = [];
+
+  // Add columns in canonical order
+  for (const canonicalId of CANONICAL_COLUMN_ORDER) {
+    if (columnSet.has(canonicalId)) {
+      sorted.push(canonicalId);
+    }
+  }
+
+  // Append unknown columns at the end (preserves forward compatibility)
+  for (const col of columns) {
+    if (!CANONICAL_COLUMN_ORDER.includes(col)) {
+      sorted.push(col);
+    }
+  }
+
+  return sorted;
+}
+
+export const DEFAULT_TABLE_COLUMNS = ['status', 'title', 'due', 'tags', 'timeTracked', 'subtasks'];
 
 export interface ViewPreferences {
   viewMode: ViewMode;
@@ -32,7 +83,7 @@ export const useViewPreferences = (): UseViewPreferencesReturn => {
   );
 
   const tableColumns = useMemo<string[]>(
-    () => profile?.preferences?.tableColumns || DEFAULT_TABLE_COLUMNS,
+    () => sortColumnsByCanonicalOrder(profile?.preferences?.tableColumns || DEFAULT_TABLE_COLUMNS),
     [profile?.preferences?.tableColumns],
   );
 


### PR DESCRIPTION
Fix table column order in gear icon popover - columns now always display in canonical order regardless of stored preferences.

## Problem
- Gear icon dropdown showed table columns in wrong order
- Clicking a column in the popover changed the order
- Order couldn't be re-sorted after interaction

## Solution
- Added `AVAILABLE_COLUMNS` constant defining canonical column order
- Added `sortColumnsByCanonicalOrder()` helper function
- Hook now always returns columns sorted by canonical order on read
- Preferences store only visibility (which columns), not order

## Changes
- `use_view_preferences.ts`: Added constants and sorting logic
- `view_settings_popover.tsx`: Uses shared constants
- `use_view_preferences.test.ts`: Added 8 new tests for column ordering