### PR TITLE
feat: add optional message field to audit log entries

### DIFF
--- a/.changeset/audit-log-message-field.md
+++ b/.changeset/audit-log-message-field.md
@@ -1,0 +1,9 @@
+---
+"@eddo/core-shared": minor
+"@eddo/core-server": minor
+"@eddo/mcp-server": minor
+"@eddo/web-api": minor
+"@eddo/web-client": minor
+---
+
+Add optional message field to audit log entries for human-readable activity descriptions

--- a/packages/core-server/src/api/audit-service.ts
+++ b/packages/core-server/src/api/audit-service.ts
@@ -31,6 +31,8 @@ export interface LogActionOptions {
   before?: Partial<TodoAlpha3>;
   /** Todo state after the action (for create/update) */
   after?: Partial<TodoAlpha3>;
+  /** Optional human-readable message describing the action (short, like a git commit message) */
+  message?: string;
   /** Optional additional metadata */
   metadata?: Record<string, unknown>;
 }
@@ -87,6 +89,7 @@ async function logAction(
     source: options.source,
     before: options.before,
     after: options.after,
+    message: options.message,
     metadata: options.metadata,
   });
 

--- a/packages/core-shared/src/versions/audit_log_alpha1.test.ts
+++ b/packages/core-shared/src/versions/audit_log_alpha1.test.ts
@@ -98,6 +98,35 @@ describe('audit_log_alpha1', () => {
       expect(entry.metadata).toEqual({ userId: 'user123', reason: 'cleanup' });
     });
 
+    it('creates entry with message', () => {
+      const input: NewAuditLogEntry = {
+        action: 'update',
+        entityType: 'todo',
+        entityId: '2026-01-07T11:00:00.000Z',
+        source: 'mcp',
+        before: { title: 'My todo' },
+        after: { title: 'My todo', due: '2026-01-14' },
+        message: 'Added due date for next week',
+      };
+
+      const entry = createAuditLogEntry(input);
+
+      expect(entry.message).toBe('Added due date for next week');
+    });
+
+    it('creates entry without message (backward compatible)', () => {
+      const input: NewAuditLogEntry = {
+        action: 'create',
+        entityType: 'todo',
+        entityId: '2026-01-07T11:00:00.000Z',
+        source: 'web',
+      };
+
+      const entry = createAuditLogEntry(input);
+
+      expect(entry.message).toBeUndefined();
+    });
+
     it('creates entry for time tracking actions', () => {
       const startInput: NewAuditLogEntry = {
         action: 'time_tracking_start',

--- a/packages/core-shared/src/versions/audit_log_alpha1.ts
+++ b/packages/core-shared/src/versions/audit_log_alpha1.ts
@@ -45,6 +45,8 @@ export interface AuditLogAlpha1 {
   after?: Partial<TodoAlpha3>;
   /** Source system that triggered the action */
   source: AuditSource;
+  /** Optional human-readable message describing the action (short, like a git commit message) */
+  message?: string;
   /** Optional metadata for additional context */
   metadata?: Record<string, unknown>;
 }

--- a/packages/mcp_server/src/tools/audit-helper.ts
+++ b/packages/mcp_server/src/tools/audit-helper.ts
@@ -28,6 +28,8 @@ export interface McpAuditOptions {
   entityId: string;
   before?: Partial<TodoAlpha3>;
   after?: Partial<TodoAlpha3>;
+  /** Optional human-readable message describing the action (short, like a git commit message) */
+  message?: string;
   metadata?: Record<string, unknown>;
 }
 
@@ -57,6 +59,7 @@ export async function logMcpAudit(context: ToolContext, options: McpAuditOptions
       source: 'mcp',
       before: options.before,
       after: options.after,
+      message: options.message,
       metadata: options.metadata,
     });
 

--- a/packages/mcp_server/src/tools/create-todo.ts
+++ b/packages/mcp_server/src/tools/create-todo.ts
@@ -100,6 +100,12 @@ export const createTodoParameters = z.object({
     .describe(
       'Optional key-value metadata for extensibility. Use namespaced keys (e.g., "agent:worktree", "github:labels", "rss:feed_title").',
     ),
+  message: z
+    .string()
+    .optional()
+    .describe(
+      'Optional human-readable audit message describing why this todo was created (short, like a git commit message).',
+    ),
 });
 
 export type CreateTodoArgs = z.infer<typeof createTodoParameters>;
@@ -180,6 +186,7 @@ export async function executeCreateTodo(
       action: 'create',
       entityId: newTodo._id,
       after: newTodo,
+      message: args.message,
     });
 
     return createSuccessResponse({

--- a/packages/mcp_server/src/tools/delete-todo.ts
+++ b/packages/mcp_server/src/tools/delete-todo.ts
@@ -16,6 +16,12 @@ export const deleteTodoParameters = z.object({
   id: z
     .string()
     .describe('The unique identifier of the todo to delete (ISO timestamp of creation)'),
+  message: z
+    .string()
+    .optional()
+    .describe(
+      'Optional human-readable audit message describing why this todo was deleted (short, like a git commit message).',
+    ),
 });
 
 export type DeleteTodoArgs = z.infer<typeof deleteTodoParameters>;
@@ -48,6 +54,7 @@ export async function executeDeleteTodo(
       action: 'delete',
       entityId: todo._id,
       before: todo,
+      message: args.message,
     });
 
     context.log.info('Todo deleted successfully', { title: todo.title });

--- a/packages/mcp_server/src/tools/update-todo.ts
+++ b/packages/mcp_server/src/tools/update-todo.ts
@@ -42,6 +42,12 @@ export const updateTodoParameters = z.object({
     .describe(
       'Key-value metadata for extensibility. Use namespaced keys (e.g., "agent:worktree", "github:labels"). Replaces entire metadata object when provided.',
     ),
+  message: z
+    .string()
+    .optional()
+    .describe(
+      'Optional human-readable audit message describing why this update was made (short, like a git commit message).',
+    ),
 });
 
 export type UpdateTodoArgs = z.infer<typeof updateTodoParameters>;
@@ -104,6 +110,7 @@ export async function executeUpdateTodo(
       entityId: result.id,
       before: todo,
       after: updated,
+      message: args.message,
     });
     context.log.info('Todo updated successfully', { id: result.id, title: updated.title });
 

--- a/packages/web-api/src/utils/sync-audit.ts
+++ b/packages/web-api/src/utils/sync-audit.ts
@@ -29,6 +29,8 @@ export interface SyncAuditOptions {
   entityId: string;
   before?: Partial<TodoAlpha3>;
   after?: Partial<TodoAlpha3>;
+  /** Optional human-readable message describing the action (short, like a git commit message) */
+  message?: string;
   metadata?: Record<string, unknown>;
 }
 
@@ -37,7 +39,7 @@ export interface SyncAuditOptions {
  * Silently fails if audit logging encounters an error (non-blocking).
  */
 export async function logSyncAudit(options: SyncAuditOptions): Promise<void> {
-  const { username, source, action, entityId, before, after, metadata } = options;
+  const { username, source, action, entityId, before, after, message, metadata } = options;
 
   try {
     const env = getEnv();
@@ -50,6 +52,7 @@ export async function logSyncAudit(options: SyncAuditOptions): Promise<void> {
       source,
       before,
       after,
+      message,
       metadata,
     });
   } catch (error) {

--- a/packages/web-client/src/components/audit_sidebar.test.tsx
+++ b/packages/web-client/src/components/audit_sidebar.test.tsx
@@ -130,6 +130,71 @@ describe('AuditSidebar with entries', () => {
     expect(screen.getByText(/Created/)).toBeInTheDocument();
   });
 
+  it('renders message when present', async () => {
+    const mockEntries = [
+      {
+        _id: '2026-01-07T12:00:00.000Z',
+        version: 'audit_alpha1' as const,
+        action: 'update' as const,
+        entityType: 'todo' as const,
+        entityId: '2026-01-07T11:00:00.000Z',
+        timestamp: '2026-01-07T12:00:00.000Z',
+        source: 'mcp' as const,
+        after: { title: 'Test Todo' },
+        message: 'Added due date for next week',
+      },
+    ];
+
+    const { useAuditLog } = await import('../hooks/use_audit_log_data');
+    vi.mocked(useAuditLog).mockReturnValue({
+      entries: mockEntries,
+      isLoading: false,
+      error: null,
+      hasMore: false,
+      isConnected: true,
+      connectionError: null,
+      refresh: vi.fn(),
+      reconnect: vi.fn(),
+    });
+
+    renderWithProviders(<AuditSidebar isOpen={true} />);
+    expect(screen.getByText('Test Todo')).toBeInTheDocument();
+    expect(screen.getByText('Added due date for next week')).toBeInTheDocument();
+  });
+
+  it('does not render message element when not present', async () => {
+    const mockEntries = [
+      {
+        _id: '2026-01-07T12:00:00.000Z',
+        version: 'audit_alpha1' as const,
+        action: 'create' as const,
+        entityType: 'todo' as const,
+        entityId: '2026-01-07T11:00:00.000Z',
+        timestamp: '2026-01-07T12:00:00.000Z',
+        source: 'web' as const,
+        after: { title: 'Test Todo Without Message' },
+      },
+    ];
+
+    const { useAuditLog } = await import('../hooks/use_audit_log_data');
+    vi.mocked(useAuditLog).mockReturnValue({
+      entries: mockEntries,
+      isLoading: false,
+      error: null,
+      hasMore: false,
+      isConnected: true,
+      connectionError: null,
+      refresh: vi.fn(),
+      reconnect: vi.fn(),
+    });
+
+    renderWithProviders(<AuditSidebar isOpen={true} />);
+    expect(screen.getByText('Test Todo Without Message')).toBeInTheDocument();
+    // No italic message element should exist
+    const italicElements = document.querySelectorAll('.italic');
+    expect(italicElements).toHaveLength(0);
+  });
+
   it('makes entries clickable and fetches todo on click', async () => {
     const mockTodo: Todo = {
       _id: '2026-01-07T11:00:00.000Z',

--- a/packages/web-client/src/components/audit_sidebar.tsx
+++ b/packages/web-client/src/components/audit_sidebar.tsx
@@ -126,6 +126,11 @@ const AuditEntryItem: FC<AuditEntryItemProps> = ({ entry, onEntryClick, isDelete
       type="button"
     >
       <p className="truncate text-sm font-medium text-neutral-900 dark:text-neutral-100">{title}</p>
+      {entry.message && (
+        <p className="truncate text-xs text-neutral-600 italic dark:text-neutral-300">
+          {entry.message}
+        </p>
+      )}
       <p className="flex items-center gap-1 text-xs text-neutral-500 dark:text-neutral-400">
         <span className={`font-mono text-xs ${actionConfig.color}`}>{actionConfig.icon}</span>
         {actionConfig.label}


### PR DESCRIPTION
## Summary
Add an optional `message` field to audit log entries for human-readable activity descriptions. Messages are short and concise (like a git commit message).

## Changes
- Add `message?: string` to `AuditLogAlpha1` interface
- Flow through all audit helpers: `audit-service.ts`, `audit-helper.ts` (MCP), `sync-audit.ts`
- Add `message` parameter to MCP tools (create, update, delete, complete, time-tracking)
- Display message in activity sidebar when present (italic, below title)
- Backward compatible: existing entries without message continue to work

## Usage
The eddo-todo skill CLI now supports `-m`/`--message` flag:
```bash
eddo.js create "Fix bug" -c work -m "Reported by user in #support"
eddo.js update <id> -d 2025-01-15 -m "Pushed to next week, blocked on API"
eddo.js complete <id> -m "Fixed the auth bug"
```

Closes #425