### PR TITLE
feat(web-client): replace metadata JSON editor with key/value CRUD UI

### DIFF
--- a/.changeset/metadata-ui-crud.md
+++ b/.changeset/metadata-ui-crud.md
@@ -1,0 +1,5 @@
+---
+"eddo-app": minor
+---
+
+Replace metadata JSON editor with user-friendly key/value CRUD interface with namespace suggestions

--- a/packages/web-client/src/components/todo_metadata_field.tsx
+++ b/packages/web-client/src/components/todo_metadata_field.tsx
@@ -1,74 +1,285 @@
 /**
  * Metadata field component for todo editing
+ * Provides a key/value CRUD interface instead of raw JSON editing
  */
 import { type Todo } from '@eddo/core-client';
-import { Label, Textarea } from 'flowbite-react';
+import { Button, Label, TextInput } from 'flowbite-react';
 import { type FC, useState } from 'react';
+import { BiPlus, BiTrash } from 'react-icons/bi';
 
 interface TodoFieldProps {
   todo: Todo;
   onChange: (updater: (todo: Todo) => Todo) => void;
 }
 
-/**
- * Parses metadata from JSON string, returns undefined on error
- */
-function parseMetadata(value: string): Record<string, string> | undefined {
-  if (value.trim() === '') return undefined;
-  try {
-    const parsed = JSON.parse(value);
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return undefined;
-    // Validate all values are strings
-    for (const v of Object.values(parsed)) {
-      if (typeof v !== 'string') return undefined;
-    }
-    return parsed as Record<string, string>;
-  } catch {
-    return undefined;
-  }
+interface MetadataEntry {
+  key: string;
+  value: string;
 }
 
-export const MetadataField: FC<TodoFieldProps> = ({ todo, onChange }) => {
-  const [localValue, setLocalValue] = useState(
-    todo.metadata ? JSON.stringify(todo.metadata, null, 2) : '',
-  );
-  const [isValid, setIsValid] = useState(true);
+/** Common namespace prefixes for metadata keys */
+const KEY_SUGGESTIONS = [
+  'agent:session',
+  'agent:model',
+  'agent:cwd',
+  'agent:branch',
+  'agent:name',
+  'agent:worktree',
+  'github:labels',
+  'github:milestone',
+  'rss:feed_title',
+  'rss:pub_date',
+];
 
-  const handleChange = (value: string) => {
-    setLocalValue(value);
-    if (value.trim() === '') {
-      setIsValid(true);
-      onChange((t) => ({ ...t, metadata: undefined }));
-      return;
+interface MetadataRowProps {
+  entry: MetadataEntry;
+  onKeyChange: (newKey: string) => void;
+  onValueChange: (newValue: string) => void;
+  onDelete: () => void;
+  isKeyDuplicate: boolean;
+}
+
+const MetadataRow: FC<MetadataRowProps> = ({
+  entry,
+  onKeyChange,
+  onValueChange,
+  onDelete,
+  isKeyDuplicate,
+}) => (
+  <div className="flex items-center gap-2">
+    <div className="flex-1">
+      <TextInput
+        aria-label="Metadata key"
+        className={isKeyDuplicate ? 'border-red-500' : ''}
+        list="metadata-key-suggestions"
+        onChange={(e) => onKeyChange(e.target.value)}
+        placeholder="key (e.g., agent:name)"
+        sizing="sm"
+        type="text"
+        value={entry.key}
+      />
+    </div>
+    <div className="flex-1">
+      <TextInput
+        aria-label="Metadata value"
+        onChange={(e) => onValueChange(e.target.value)}
+        placeholder="value"
+        sizing="sm"
+        type="text"
+        value={entry.value}
+      />
+    </div>
+    <Button aria-label="Delete metadata entry" color="red" onClick={onDelete} size="xs">
+      <BiTrash size="1em" />
+    </Button>
+  </div>
+);
+
+interface AddMetadataRowProps {
+  onAdd: (key: string, value: string) => void;
+}
+
+/** Hook for managing new entry input state */
+function useNewEntryState() {
+  const [newKey, setNewKey] = useState('');
+  const [newValue, setNewValue] = useState('');
+
+  const reset = () => {
+    setNewKey('');
+    setNewValue('');
+  };
+
+  return { newKey, setNewKey, newValue, setNewValue, reset };
+}
+
+interface AddRowInputsProps {
+  newKey: string;
+  newValue: string;
+  onKeyChange: (value: string) => void;
+  onValueChange: (value: string) => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+}
+
+const AddRowInputs: FC<AddRowInputsProps> = (props) => (
+  <>
+    <div className="flex-1">
+      <TextInput
+        aria-label="New metadata key"
+        list="metadata-key-suggestions"
+        onChange={(e) => props.onKeyChange(e.target.value)}
+        onKeyDown={props.onKeyDown}
+        placeholder="new key"
+        sizing="sm"
+        type="text"
+        value={props.newKey}
+      />
+    </div>
+    <div className="flex-1">
+      <TextInput
+        aria-label="New metadata value"
+        onChange={(e) => props.onValueChange(e.target.value)}
+        onKeyDown={props.onKeyDown}
+        placeholder="new value"
+        sizing="sm"
+        type="text"
+        value={props.newValue}
+      />
+    </div>
+  </>
+);
+
+const AddMetadataRow: FC<AddMetadataRowProps> = ({ onAdd }) => {
+  const { newKey, setNewKey, newValue, setNewValue, reset } = useNewEntryState();
+
+  const handleAdd = () => {
+    if (newKey.trim()) {
+      onAdd(newKey.trim(), newValue);
+      reset();
     }
-    const parsed = parseMetadata(value);
-    if (parsed !== undefined) {
-      setIsValid(true);
-      onChange((t) => ({ ...t, metadata: parsed }));
-    } else {
-      setIsValid(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && newKey.trim()) {
+      e.preventDefault();
+      handleAdd();
     }
   };
 
   return (
+    <div className="flex items-center gap-2">
+      <AddRowInputs
+        newKey={newKey}
+        newValue={newValue}
+        onKeyChange={setNewKey}
+        onKeyDown={handleKeyDown}
+        onValueChange={setNewValue}
+      />
+      <Button
+        aria-label="Add metadata entry"
+        color="blue"
+        disabled={!newKey.trim()}
+        onClick={handleAdd}
+        size="xs"
+      >
+        <BiPlus size="1em" />
+      </Button>
+    </div>
+  );
+};
+
+/** Convert metadata object to array of entries for editing */
+function metadataToEntries(metadata: Record<string, string> | undefined): MetadataEntry[] {
+  if (!metadata) return [];
+  return Object.entries(metadata).map(([key, value]) => ({ key, value }));
+}
+
+/** Convert entries array back to metadata object */
+function entriesToMetadata(entries: MetadataEntry[]): Record<string, string> | undefined {
+  const validEntries = entries.filter((e) => e.key.trim() !== '');
+  if (validEntries.length === 0) return undefined;
+  return Object.fromEntries(validEntries.map((e) => [e.key, e.value]));
+}
+
+/** Find duplicate keys in entries */
+function findDuplicateKeys(entries: MetadataEntry[]): Set<string> {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const entry of entries) {
+    const key = entry.key.trim();
+    if (key && seen.has(key)) {
+      duplicates.add(key);
+    }
+    seen.add(key);
+  }
+  return duplicates;
+}
+
+interface MetadataHandlers {
+  handleKeyChange: (index: number, newKey: string) => void;
+  handleValueChange: (index: number, newValue: string) => void;
+  handleDelete: (index: number) => void;
+  handleAdd: (key: string, value: string) => void;
+}
+
+/** Hook for metadata entry CRUD operations */
+function useMetadataHandlers(
+  entries: MetadataEntry[],
+  setEntries: React.Dispatch<React.SetStateAction<MetadataEntry[]>>,
+  onChange: TodoFieldProps['onChange'],
+): MetadataHandlers {
+  const updateEntries = (newEntries: MetadataEntry[]) => {
+    setEntries(newEntries);
+    onChange((t) => ({ ...t, metadata: entriesToMetadata(newEntries) }));
+  };
+
+  return {
+    handleKeyChange: (index: number, newKey: string) => {
+      const newEntries = [...entries];
+      newEntries[index] = { ...newEntries[index], key: newKey };
+      updateEntries(newEntries);
+    },
+    handleValueChange: (index: number, newValue: string) => {
+      const newEntries = [...entries];
+      newEntries[index] = { ...newEntries[index], value: newValue };
+      updateEntries(newEntries);
+    },
+    handleDelete: (index: number) => {
+      updateEntries(entries.filter((_, i) => i !== index));
+    },
+    handleAdd: (key: string, value: string) => {
+      updateEntries([...entries, { key, value }]);
+    },
+  };
+}
+
+interface MetadataListProps {
+  entries: MetadataEntry[];
+  duplicateKeys: Set<string>;
+  handlers: MetadataHandlers;
+}
+
+const MetadataList: FC<MetadataListProps> = ({ entries, duplicateKeys, handlers }) => (
+  <div className="space-y-2">
+    {entries.map((entry, index) => (
+      <MetadataRow
+        entry={entry}
+        isKeyDuplicate={duplicateKeys.has(entry.key.trim())}
+        key={index}
+        onDelete={() => handlers.handleDelete(index)}
+        onKeyChange={(newKey) => handlers.handleKeyChange(index, newKey)}
+        onValueChange={(newValue) => handlers.handleValueChange(index, newValue)}
+      />
+    ))}
+    <AddMetadataRow onAdd={handlers.handleAdd} />
+  </div>
+);
+
+/** Datalist for key suggestions - rendered once and shared */
+const KeySuggestionsDatalist: FC = () => (
+  <datalist id="metadata-key-suggestions">
+    {KEY_SUGGESTIONS.map((key) => (
+      <option key={key} value={key} />
+    ))}
+  </datalist>
+);
+
+export const MetadataField: FC<TodoFieldProps> = ({ todo, onChange }) => {
+  const [entries, setEntries] = useState<MetadataEntry[]>(() => metadataToEntries(todo.metadata));
+  const duplicateKeys = findDuplicateKeys(entries);
+  const handlers = useMetadataHandlers(entries, setEntries, onChange);
+
+  return (
     <div>
       <div className="mb-2 block">
-        <Label htmlFor="eddoTodoMetadata">Metadata (JSON)</Label>
+        <Label>Metadata {entries.length > 0 && `(${entries.length})`}</Label>
       </div>
-      <Textarea
-        aria-label="Metadata"
-        className={!isValid ? 'border-red-500 dark:border-red-500' : ''}
-        id="eddoTodoMetadata"
-        onChange={(e) => handleChange(e.target.value)}
-        placeholder='{"agent:worktree": "/path/to/worktree"}'
-        rows={3}
-        value={localValue}
-      />
-      {!isValid && (
+      <MetadataList duplicateKeys={duplicateKeys} entries={entries} handlers={handlers} />
+      {duplicateKeys.size > 0 && (
         <p className="mt-1 text-sm text-red-500">
-          Invalid JSON. Must be an object with string values.
+          Duplicate keys detected. Each key must be unique.
         </p>
       )}
+      <KeySuggestionsDatalist />
     </div>
   );
 };

--- a/packages/web-client/src/components/todo_metadata_view.tsx
+++ b/packages/web-client/src/components/todo_metadata_view.tsx
@@ -1,0 +1,42 @@
+/**
+ * Read-only metadata view component for todo display
+ */
+import { type FC } from 'react';
+
+/** Label styling for field headers */
+const LABEL_CLASS =
+  'text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wide';
+
+interface MetadataViewProps {
+  metadata: Record<string, string> | undefined;
+}
+
+export const MetadataView: FC<MetadataViewProps> = ({ metadata }) => {
+  if (!metadata || Object.keys(metadata).length === 0) {
+    return null;
+  }
+
+  const entries = Object.entries(metadata);
+
+  return (
+    <div>
+      <div className={LABEL_CLASS}>Metadata ({entries.length})</div>
+      <div className="mt-2 rounded-lg border border-neutral-200 bg-neutral-50 dark:border-neutral-600 dark:bg-neutral-900/50">
+        <table className="w-full">
+          <tbody className="divide-y divide-neutral-200 dark:divide-neutral-700">
+            {entries.map(([key, value]) => (
+              <tr key={key}>
+                <td className="px-3 py-2 align-top font-mono text-xs font-medium whitespace-nowrap text-neutral-600 dark:text-neutral-400">
+                  {key}
+                </td>
+                <td className="px-3 py-2 align-top font-mono text-xs break-all text-neutral-900 dark:text-white">
+                  {value}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/packages/web-client/src/components/todo_view_fields.tsx
+++ b/packages/web-client/src/components/todo_view_fields.tsx
@@ -15,6 +15,7 @@ import remarkGfm from 'remark-gfm';
 import { useChildTodos, useParentTodo } from '../hooks/use_parent_child';
 import { TEXT_LINK } from '../styles/interactive';
 import { TagDisplay } from './tag_display';
+import { MetadataView } from './todo_metadata_view';
 
 interface TodoViewFieldsProps {
   todo: Todo;
@@ -317,6 +318,7 @@ export const TodoViewFields: FC<TodoViewFieldsProps> = ({ todo }) => (
     <NotesView notes={todo.notes} />
     <LinkView link={todo.link} />
     <ExternalIdView externalId={todo.externalId ?? null} />
+    <MetadataView metadata={todo.metadata} />
     <TimeTrackingView active={todo.active} />
 
     <div className="grid grid-cols-2 gap-4 border-t border-neutral-200 pt-4 dark:border-neutral-700">


### PR DESCRIPTION
Closes #427

## Summary
Replace the raw JSON textarea for metadata editing with a user-friendly key/value interface.

## Changes
- Key/value CRUD interface (add/edit/delete entries)
- Namespace prefix suggestions via datalist (agent:, github:, rss:)
- Read-only table view for metadata display in view mode
- Duplicate key detection with warning
- 10 tests covering all functionality

## Files
- `todo_metadata_field.tsx` - New CRUD interface
- `todo_metadata_field.test.tsx` - Updated tests  
- `todo_metadata_view.tsx` - New view component
- `todo_view_fields.tsx` - Added MetadataView