### PR TITLE
fix: show metadata nodes for all sessions

### DIFF
--- a/packages/web-client/src/components/todo_graph_helpers.test.ts
+++ b/packages/web-client/src/components/todo_graph_helpers.test.ts
@@ -117,7 +117,7 @@ describe('createAllNodes', () => {
       expect(metadataNodes[0].data.todoCount).toBe(2);
     });
 
-    it('does not create metadata node for single todo', () => {
+    it('creates metadata node for single todo', () => {
       const todos = [
         createMockTodo({
           _id: 'todo-1',
@@ -128,7 +128,8 @@ describe('createAllNodes', () => {
       const nodes = createAllNodes(todos, []);
 
       const metadataNodes = nodes.filter((n) => n.type === 'metadataNode');
-      expect(metadataNodes).toHaveLength(0);
+      expect(metadataNodes).toHaveLength(1);
+      expect(metadataNodes[0].data.todoCount).toBe(1);
     });
 
     it('creates separate nodes for different sessions', () => {

--- a/packages/web-client/src/components/todo_graph_helpers.ts
+++ b/packages/web-client/src/components/todo_graph_helpers.ts
@@ -238,23 +238,20 @@ export function createMetadataNodes(todos: Todo[], auditEntries: AuditLogAlpha1[
     }
   }
 
-  // Only create nodes for metadata shared by 2+ todos (more interesting groupings)
   const nodes: Node[] = [];
   let index = 0;
 
   for (const [nodeId, { key, value, todoIds }] of metadataMap) {
-    if (todoIds.size >= 2) {
-      // Find last message for agent-related nodes
-      const lastMessage = getLastMessageForMetadata(key, value, todos, auditEntries);
+    // Find last message for agent-related nodes
+    const lastMessage = getLastMessageForMetadata(key, value, todos, auditEntries);
 
-      nodes.push({
-        id: nodeId,
-        type: 'metadataNode',
-        position: { x: -200 + (index % 3) * 220, y: -150 + Math.floor(index / 3) * 100 },
-        data: { metadataKey: key, metadataValue: value, todoCount: todoIds.size, lastMessage },
-      });
-      index++;
-    }
+    nodes.push({
+      id: nodeId,
+      type: 'metadataNode',
+      position: { x: -200 + (index % 3) * 220, y: -150 + Math.floor(index / 3) * 100 },
+      data: { metadataKey: key, metadataValue: value, todoCount: todoIds.size, lastMessage },
+    });
+    index++;
   }
 
   return nodes;
@@ -335,11 +332,9 @@ export function createMetadataEdges(todos: Todo[]): Edge[] {
   const metadataMap = buildMetadataMap(todos);
 
   for (const [metadataNodeId, todoIds] of metadataMap) {
-    if (todoIds.size >= 2) {
-      for (const todoId of todoIds) {
-        const todo = todoMap.get(todoId);
-        edges.push(createMetadataEdge(metadataNodeId, todoId, !!todo?.completed));
-      }
+    for (const todoId of todoIds) {
+      const todo = todoMap.get(todoId);
+      edges.push(createMetadataEdge(metadataNodeId, todoId, !!todo?.completed));
     }
   }
 


### PR DESCRIPTION
Remove the filter that only showed metadata nodes when 2+ todos shared the same session. This was non-transparent for users - all session nodes should be visible regardless of todo count.

Closes #432