### PR TITLE
feat(web-client): add keyboard date navigation with arrow keys

### DIFF
--- a/.changeset/date-navigation-keys.md
+++ b/.changeset/date-navigation-keys.md
@@ -1,0 +1,5 @@
+---
+"@eddo/web-client": patch
+---
+
+Add keyboard navigation for date periods - left/right arrow keys navigate to previous/next period

--- a/packages/web-client/src/components/todo_filters.tsx
+++ b/packages/web-client/src/components/todo_filters.tsx
@@ -3,6 +3,7 @@
  */
 import { type FC, useCallback } from 'react';
 
+import { useDateNavigationKeys } from '../hooks/use_date_navigation_keys';
 import { useEddoContexts } from '../hooks/use_eddo_contexts';
 import type { CurrentFilterState } from '../hooks/use_filter_presets';
 import { useTags } from '../hooks/use_tags';
@@ -22,7 +23,6 @@ function useApplyPresetHandler(props: TodoFiltersProps) {
   return useCallback(
     (filters: CurrentFilterState) => {
       if (props.batchUpdateFilters) {
-        // Use batch update to avoid conflicts
         props.batchUpdateFilters({
           selectedTags: filters.selectedTags,
           selectedContexts: filters.selectedContexts,
@@ -31,7 +31,6 @@ function useApplyPresetHandler(props: TodoFiltersProps) {
           currentDate: filters.currentDate,
         });
       } else {
-        // Fallback to individual setters
         props.setSelectedTags(filters.selectedTags);
         props.setSelectedContexts(filters.selectedContexts);
         props.setSelectedStatus(filters.selectedStatus);
@@ -50,14 +49,25 @@ function useApplyPresetHandler(props: TodoFiltersProps) {
   );
 }
 
+/** Hook for period navigation with keyboard support (left/right arrows) */
+function usePeriodNavigation(props: TodoFiltersProps) {
+  const handleNavigate = useCallback(
+    (direction: 'prev' | 'next') => {
+      props.setCurrentDate(navigatePeriod(props.currentDate, props.selectedTimeRange, direction));
+    },
+    [props.currentDate, props.selectedTimeRange, props.setCurrentDate],
+  );
+
+  useDateNavigationKeys({ timeRange: props.selectedTimeRange, onNavigate: handleNavigate });
+
+  return handleNavigate;
+}
+
 export const TodoFilters: FC<TodoFiltersProps> = (props) => {
   const { allTags } = useTags();
   const { allContexts } = useEddoContexts();
   const handleApplyPreset = useApplyPresetHandler(props);
-
-  const handleNavigate = (direction: 'prev' | 'next') => {
-    props.setCurrentDate(navigatePeriod(props.currentDate, props.selectedTimeRange, direction));
-  };
+  const handleNavigate = usePeriodNavigation(props);
 
   return (
     <div className="flex items-center justify-between bg-white pb-3 dark:bg-neutral-800">

--- a/packages/web-client/src/hooks/use_date_navigation_keys.test.ts
+++ b/packages/web-client/src/hooks/use_date_navigation_keys.test.ts
@@ -1,0 +1,182 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TimeRange } from '../components/time_range_filter';
+
+import { useDateNavigationKeys } from './use_date_navigation_keys';
+
+describe('useDateNavigationKeys', () => {
+  const mockOnNavigate = vi.fn();
+
+  beforeEach(() => {
+    mockOnNavigate.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const dayTimeRange: TimeRange = { type: 'current-day' };
+  const allTimeRange: TimeRange = { type: 'all-time' };
+
+  const fireKeyEvent = (key: string, options: Partial<KeyboardEvent> = {}) => {
+    const event = new KeyboardEvent('keydown', {
+      key,
+      bubbles: true,
+      ...options,
+    });
+    document.dispatchEvent(event);
+  };
+
+  it('should call onNavigate with "prev" when ArrowLeft is pressed', () => {
+    renderHook(() =>
+      useDateNavigationKeys({
+        timeRange: dayTimeRange,
+        onNavigate: mockOnNavigate,
+      }),
+    );
+
+    fireKeyEvent('ArrowLeft');
+
+    expect(mockOnNavigate).toHaveBeenCalledWith('prev');
+    expect(mockOnNavigate).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onNavigate with "next" when ArrowRight is pressed', () => {
+    renderHook(() =>
+      useDateNavigationKeys({
+        timeRange: dayTimeRange,
+        onNavigate: mockOnNavigate,
+      }),
+    );
+
+    fireKeyEvent('ArrowRight');
+
+    expect(mockOnNavigate).toHaveBeenCalledWith('next');
+    expect(mockOnNavigate).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not navigate when time range is all-time', () => {
+    renderHook(() =>
+      useDateNavigationKeys({
+        timeRange: allTimeRange,
+        onNavigate: mockOnNavigate,
+      }),
+    );
+
+    fireKeyEvent('ArrowLeft');
+    fireKeyEvent('ArrowRight');
+
+    expect(mockOnNavigate).not.toHaveBeenCalled();
+  });
+
+  it('should not navigate when disabled', () => {
+    renderHook(() =>
+      useDateNavigationKeys({
+        timeRange: dayTimeRange,
+        onNavigate: mockOnNavigate,
+        enabled: false,
+      }),
+    );
+
+    fireKeyEvent('ArrowLeft');
+    fireKeyEvent('ArrowRight');
+
+    expect(mockOnNavigate).not.toHaveBeenCalled();
+  });
+
+  it('should not navigate when modifier keys are pressed', () => {
+    renderHook(() =>
+      useDateNavigationKeys({
+        timeRange: dayTimeRange,
+        onNavigate: mockOnNavigate,
+      }),
+    );
+
+    fireKeyEvent('ArrowLeft', { metaKey: true });
+    fireKeyEvent('ArrowLeft', { ctrlKey: true });
+    fireKeyEvent('ArrowLeft', { altKey: true });
+
+    expect(mockOnNavigate).not.toHaveBeenCalled();
+  });
+
+  it('should not navigate when typing in an input', () => {
+    renderHook(() =>
+      useDateNavigationKeys({
+        timeRange: dayTimeRange,
+        onNavigate: mockOnNavigate,
+      }),
+    );
+
+    // Create an input element and focus it
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+
+    // Dispatch event with input as target
+    const event = new KeyboardEvent('keydown', {
+      key: 'ArrowLeft',
+      bubbles: true,
+    });
+    Object.defineProperty(event, 'target', { value: input });
+    document.dispatchEvent(event);
+
+    expect(mockOnNavigate).not.toHaveBeenCalled();
+
+    document.body.removeChild(input);
+  });
+
+  it('should not navigate when typing in a textarea', () => {
+    renderHook(() =>
+      useDateNavigationKeys({
+        timeRange: dayTimeRange,
+        onNavigate: mockOnNavigate,
+      }),
+    );
+
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'ArrowLeft',
+      bubbles: true,
+    });
+    Object.defineProperty(event, 'target', { value: textarea });
+    document.dispatchEvent(event);
+
+    expect(mockOnNavigate).not.toHaveBeenCalled();
+
+    document.body.removeChild(textarea);
+  });
+
+  it('should ignore other keys', () => {
+    renderHook(() =>
+      useDateNavigationKeys({
+        timeRange: dayTimeRange,
+        onNavigate: mockOnNavigate,
+      }),
+    );
+
+    fireKeyEvent('ArrowUp');
+    fireKeyEvent('ArrowDown');
+    fireKeyEvent('Enter');
+    fireKeyEvent('a');
+
+    expect(mockOnNavigate).not.toHaveBeenCalled();
+  });
+
+  it('should cleanup event listener on unmount', () => {
+    const removeEventListenerSpy = vi.spyOn(document, 'removeEventListener');
+
+    const { unmount } = renderHook(() =>
+      useDateNavigationKeys({
+        timeRange: dayTimeRange,
+        onNavigate: mockOnNavigate,
+      }),
+    );
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+  });
+});

--- a/packages/web-client/src/hooks/use_date_navigation_keys.ts
+++ b/packages/web-client/src/hooks/use_date_navigation_keys.ts
@@ -1,0 +1,70 @@
+/**
+ * Hook for keyboard navigation of date periods
+ * Left arrow = previous period, Right arrow = next period
+ */
+import { useEffect } from 'react';
+
+import type { TimeRange } from '../components/time_range_filter';
+
+interface UseDateNavigationKeysOptions {
+  /** Current time range setting */
+  timeRange: TimeRange;
+  /** Callback to navigate to previous/next period */
+  onNavigate: (direction: 'prev' | 'next') => void;
+  /** Whether the hook is enabled (default: true) */
+  enabled?: boolean;
+}
+
+/**
+ * Check if the event target is an input element where typing should be allowed
+ */
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!target || !(target instanceof HTMLElement)) return false;
+  return (
+    target.tagName === 'INPUT' ||
+    target.tagName === 'TEXTAREA' ||
+    target.isContentEditable ||
+    target.closest('[contenteditable="true"]') !== null
+  );
+}
+
+/**
+ * Hook that enables left/right arrow key navigation for date periods.
+ *
+ * - ArrowLeft: Navigate to previous period
+ * - ArrowRight: Navigate to next period
+ *
+ * Navigation is disabled when:
+ * - User is typing in an input/textarea
+ * - Modifier keys (Ctrl, Alt, Meta) are pressed
+ * - Time range is 'all-time' (no period navigation makes sense)
+ */
+export function useDateNavigationKeys({
+  timeRange,
+  onNavigate,
+  enabled = true,
+}: UseDateNavigationKeysOptions): void {
+  useEffect(() => {
+    // Don't attach listener if disabled or if time range doesn't support navigation
+    if (!enabled || timeRange.type === 'all-time') return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Ignore if user is typing
+      if (isTypingTarget(event.target)) return;
+
+      // Ignore if modifier keys are pressed (allow browser shortcuts)
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        onNavigate('prev');
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        onNavigate('next');
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [timeRange.type, onNavigate, enabled]);
+}


### PR DESCRIPTION
Add keyboard navigation for date periods using left/right arrow keys.

## Changes
- Add `useDateNavigationKeys` hook for arrow key date navigation
- Integrate into `TodoFilters` component via `usePeriodNavigation` wrapper
- Left arrow → previous period, Right arrow → next period

## Behavior
- Works with all time range types except 'all-time'
- Ignores input when typing in inputs/textareas
- Ignores input when modifier keys (Ctrl/Alt/Cmd) are pressed

## Testing
- Added 9 unit tests for the hook
- Manual testing verified