### PR TITLE
fix(web-client): prevent render loops causing Chrome crashes

### DIFF
--- a/.changeset/fix-render-loops-chrome-crash.md
+++ b/.changeset/fix-render-loops-chrome-crash.md
@@ -1,0 +1,5 @@
+---
+"eddo-app": patch
+---
+
+Fix render loops causing Chrome "Aw, snap!" crashes in table view

--- a/packages/web-client/src/components/todo_flyout.tsx
+++ b/packages/web-client/src/components/todo_flyout.tsx
@@ -214,14 +214,11 @@ const drawerTheme = {
   },
 };
 
-export const TodoFlyout: FC<TodoFlyoutProps> = ({ onClose, show, todo }) => {
+/** Inner component that uses hooks - only rendered when flyout is open */
+const TodoFlyoutInner: FC<TodoFlyoutProps> = ({ onClose, show, todo }) => {
   const { allTags } = useTags();
   const state = useTodoFlyoutState(todo, show, onClose);
   const activeArray = Object.entries(state.editedTodo.active);
-
-  if (!show) {
-    return null;
-  }
 
   return createPortal(
     <>
@@ -254,4 +251,16 @@ export const TodoFlyout: FC<TodoFlyoutProps> = ({ onClose, show, todo }) => {
     </>,
     document.body,
   );
+};
+
+/**
+ * Flyout panel for viewing and editing todo items.
+ * Only mounts hooks when actually shown to avoid creating mutations for every row.
+ */
+export const TodoFlyout: FC<TodoFlyoutProps> = ({ onClose, show, todo }) => {
+  if (!show) {
+    return null;
+  }
+
+  return <TodoFlyoutInner onClose={onClose} show={show} todo={todo} />;
 };

--- a/packages/web-client/src/hooks/use_audited_todo_mutations.ts
+++ b/packages/web-client/src/hooks/use_audited_todo_mutations.ts
@@ -10,6 +10,7 @@ import { getRepeatTodo } from '@eddo/core-shared';
 import { usePouchDb } from '../pouch_db';
 import { withSpan } from '../telemetry';
 import { useAuditLog, type AuditAction } from './use_audit_log';
+import { recentMutations } from './use_recent_mutations';
 import {
   rollbackCache,
   snapshotCacheState,
@@ -19,8 +20,8 @@ import {
   type UpdateTodoContext,
 } from './use_todo_mutations_helpers';
 
-/** Track recently mutated document IDs to skip redundant invalidations */
-export const recentMutations = new Set<string>();
+// Re-export for backward compatibility
+export { recentMutations } from './use_recent_mutations';
 
 /**
  * Audited mutation hook for updating todos with optimistic updates.

--- a/packages/web-client/src/hooks/use_bulk_todo_mutation.ts
+++ b/packages/web-client/src/hooks/use_bulk_todo_mutation.ts
@@ -5,7 +5,7 @@ import type { Todo } from '@eddo/core-shared';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { usePouchDb } from '../pouch_db';
-import { recentMutations } from './use_todo_mutations';
+import { recentMutations } from './use_recent_mutations';
 import {
   rollbackCache,
   snapshotCacheState,

--- a/packages/web-client/src/hooks/use_database_changes.tsx
+++ b/packages/web-client/src/hooks/use_database_changes.tsx
@@ -15,7 +15,7 @@ import {
 } from 'react';
 
 import { usePouchDb } from '../pouch_db';
-import { recentMutations } from './use_todo_mutations';
+import { recentMutations } from './use_recent_mutations';
 
 /** Debounce delay for query invalidation (ms) */
 const INVALIDATION_DEBOUNCE_MS = 150;

--- a/packages/web-client/src/hooks/use_recent_mutations.ts
+++ b/packages/web-client/src/hooks/use_recent_mutations.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared set of recently mutated document IDs.
+ * Used by mutation hooks to mark documents that shouldn't trigger query invalidation
+ * from the PouchDB changes listener (since we already optimistically updated the cache).
+ */
+
+/** Track recently mutated document IDs to skip redundant invalidations */
+export const recentMutations = new Set<string>();

--- a/packages/web-client/src/hooks/use_todo_mutations.ts
+++ b/packages/web-client/src/hooks/use_todo_mutations.ts
@@ -4,6 +4,7 @@ import type { Activity, NewTodo, Todo } from '@eddo/core-shared';
 import { getRepeatTodo } from '@eddo/core-shared';
 
 import { usePouchDb } from '../pouch_db';
+import { recentMutations } from './use_recent_mutations';
 import {
   rollbackCache,
   snapshotCacheState,
@@ -13,11 +14,8 @@ import {
   type UpdateTodoContext,
 } from './use_todo_mutations_helpers';
 
-/**
- * Track recently mutated document IDs to skip redundant invalidations.
- * The changes listener checks this to avoid re-fetching data we just updated.
- */
-export const recentMutations = new Set<string>();
+// Re-export for backward compatibility
+export { recentMutations } from './use_recent_mutations';
 
 /**
  * Mutation hook for updating todos with optimistic updates.


### PR DESCRIPTION
## Summary

Fixes render loop issues that were causing Chrome "Aw, snap!" crashes, particularly in table view during date navigation.

## Changes

- **TodoFlyout optimization**: Moved hooks to inner component that only renders when `show=true`. Previously every table row was creating mutation hooks even when flyout was closed.
- **SSE debouncing**: Added 100ms debouncing to batch audit log SSE entries before updating React Query cache.
- **Shared recentMutations**: Consolidated `recentMutations` set to shared module so audited mutations properly skip redundant query invalidations.
- **useForceLayout fix**: Added `justLayoutedRef` to prevent double `setLayoutedNodes` calls when graph structure changes.

## Testing

- All 808 tests pass
- Manually verified: table view now loads successfully after date navigation