### PR TITLE
fix(web-client): improve responsive layout of header menu

### DIFF
--- a/packages/web-client/src/components/add_todo_popover.tsx
+++ b/packages/web-client/src/components/add_todo_popover.tsx
@@ -256,14 +256,14 @@ interface AddTodoTriggerProps {
 const AddTodoTrigger: FC<AddTodoTriggerProps> = ({ onClick, setReferenceRef }) => (
   <button
     aria-label="Add todo (n)"
-    className="bg-primary-600 hover:bg-primary-700 dark:bg-primary-500 dark:hover:bg-primary-600 flex h-8 items-center gap-1.5 rounded-lg px-3 text-white"
+    className="bg-primary-600 hover:bg-primary-700 dark:bg-primary-500 dark:hover:bg-primary-600 flex h-8 items-center gap-1.5 rounded-lg px-2 text-white md:px-3"
     onClick={onClick}
     ref={setReferenceRef}
     title="Add todo (n)"
     type="button"
   >
     <HiPlus className="h-4 w-4" />
-    <span className="text-sm font-medium">Add todo</span>
+    <span className="hidden text-sm font-medium md:inline">Add todo</span>
   </button>
 );
 

--- a/packages/web-client/src/components/todo_filters.tsx
+++ b/packages/web-client/src/components/todo_filters.tsx
@@ -7,7 +7,9 @@ import { useDateNavigationKeys } from '../hooks/use_date_navigation_keys';
 import { useEddoContexts } from '../hooks/use_eddo_contexts';
 import type { CurrentFilterState } from '../hooks/use_filter_presets';
 import { useTags } from '../hooks/use_tags';
+import type { ViewMode } from '../hooks/use_view_preferences';
 
+import { AddTodoPopover } from './add_todo_popover';
 import { navigatePeriod } from './todo_filters_helpers';
 import { PeriodNavigation } from './todo_filters_navigation';
 import { FilterRow } from './todo_filters_row';
@@ -63,6 +65,42 @@ function usePeriodNavigation(props: TodoFiltersProps) {
   return handleNavigate;
 }
 
+interface TopBarProps {
+  currentDate: Date;
+  selectedTimeRange: TodoFiltersProps['selectedTimeRange'];
+  isViewPrefsLoading?: boolean;
+  tableColumns: string[];
+  viewMode: ViewMode;
+  onNavigate: (direction: 'prev' | 'next') => void;
+  onReset: () => void;
+  onTableColumnsChange: TodoFiltersProps['onTableColumnsChange'];
+  onViewModeChange: TodoFiltersProps['onViewModeChange'];
+}
+
+/** Top bar with Add todo (left on mobile) + Date nav + settings (right) */
+const TopBar: FC<TopBarProps> = (props) => (
+  <div className="order-1 flex w-full items-center gap-2 xl:order-2 xl:ml-auto xl:w-auto">
+    <div className="xl:hidden">
+      <AddTodoPopover />
+    </div>
+    <div className="ml-auto flex items-center gap-2">
+      <PeriodNavigation
+        currentDate={props.currentDate}
+        onNavigate={props.onNavigate}
+        onReset={props.onReset}
+        selectedTimeRange={props.selectedTimeRange}
+      />
+      <ViewSettingsPopover
+        isLoading={props.isViewPrefsLoading}
+        onTableColumnsChange={props.onTableColumnsChange}
+        onViewModeChange={props.onViewModeChange}
+        tableColumns={props.tableColumns}
+        viewMode={props.viewMode}
+      />
+    </div>
+  </div>
+);
+
 export const TodoFilters: FC<TodoFiltersProps> = (props) => {
   const { allTags } = useTags();
   const { allContexts } = useEddoContexts();
@@ -70,8 +108,8 @@ export const TodoFilters: FC<TodoFiltersProps> = (props) => {
   const handleNavigate = usePeriodNavigation(props);
 
   return (
-    <div className="flex items-center justify-between bg-white pb-3 dark:bg-neutral-800">
-      <div className="flex items-center space-x-2">
+    <div className="flex flex-col gap-2 bg-white pb-3 xl:flex-row xl:flex-wrap xl:items-center dark:bg-neutral-800">
+      <div className="order-2 flex flex-wrap items-center gap-2 xl:order-1">
         <FilterRow
           allContexts={allContexts}
           allTags={allTags}
@@ -92,21 +130,17 @@ export const TodoFilters: FC<TodoFiltersProps> = (props) => {
           viewMode={props.viewMode}
         />
       </div>
-      <div className="flex items-center space-x-2">
-        <PeriodNavigation
-          currentDate={props.currentDate}
-          onNavigate={handleNavigate}
-          onReset={() => props.setCurrentDate(new Date())}
-          selectedTimeRange={props.selectedTimeRange}
-        />
-        <ViewSettingsPopover
-          isLoading={props.isViewPrefsLoading}
-          onTableColumnsChange={props.onTableColumnsChange}
-          onViewModeChange={props.onViewModeChange}
-          tableColumns={props.tableColumns}
-          viewMode={props.viewMode}
-        />
-      </div>
+      <TopBar
+        currentDate={props.currentDate}
+        isViewPrefsLoading={props.isViewPrefsLoading}
+        onNavigate={handleNavigate}
+        onReset={() => props.setCurrentDate(new Date())}
+        onTableColumnsChange={props.onTableColumnsChange}
+        onViewModeChange={props.onViewModeChange}
+        selectedTimeRange={props.selectedTimeRange}
+        tableColumns={props.tableColumns}
+        viewMode={props.viewMode}
+      />
     </div>
   );
 };

--- a/packages/web-client/src/components/todo_filters_navigation.tsx
+++ b/packages/web-client/src/components/todo_filters_navigation.tsx
@@ -22,15 +22,15 @@ export const PeriodNavigation: FC<PeriodNavigationProps> = ({
     <>
       <Button className="p-0" color="gray" onClick={() => onNavigate('prev')} size="xs">
         <RiArrowLeftSLine size="2em" />
-      </Button>{' '}
+      </Button>
       <button
-        className={`cursor-pointer font-semibold ${TRANSITION} hover:text-primary-600 dark:hover:text-primary-400 rounded-lg text-neutral-900 dark:text-white ${FOCUS_RING}`}
+        className={`cursor-pointer font-semibold whitespace-nowrap ${TRANSITION} hover:text-primary-600 dark:hover:text-primary-400 rounded-lg text-neutral-900 dark:text-white ${FOCUS_RING}`}
         onClick={onReset}
         title="Return to current period"
         type="button"
       >
         {getPeriodLabel(currentDate, selectedTimeRange)}
-      </button>{' '}
+      </button>
       <Button className="p-0" color="gray" onClick={() => onNavigate('next')} size="xs">
         <RiArrowRightSLine size="2em" />
       </Button>

--- a/packages/web-client/src/components/todo_filters_row.tsx
+++ b/packages/web-client/src/components/todo_filters_row.tsx
@@ -13,7 +13,10 @@ import type { FilterRowProps } from './todo_filters_types';
 
 export const FilterRow: FC<FilterRowProps> = (props) => (
   <>
-    <AddTodoPopover />
+    {/* AddTodoPopover shown here only on xl screens, otherwise in top bar */}
+    <div className="hidden xl:block">
+      <AddTodoPopover />
+    </div>
     <PresetFilterDropdown
       currentFilters={{
         selectedTags: props.selectedTags,


### PR DESCRIPTION
## Summary
Improves responsive layout of the header filter toolbar for narrower viewports.

## Changes
- **Responsive two-row layout**: On screens < 1280px (xl), the toolbar splits into two rows:
  - Top row: Add todo button (left) + date navigation + settings gear (right)
  - Bottom row: Filter buttons (Presets, Day, All, Context, Tags) with flex-wrap
- **Responsive Add todo button**: Shows only "+" icon on screens < 768px (md) to handle Activity sidebar width
- **Cleaned up spacing**: Removed inline space characters, using gap utilities for consistent spacing

## Files Changed
- `packages/web-client/src/components/todo_filters.tsx` - Responsive layout with TopBar component
- `packages/web-client/src/components/todo_filters_row.tsx` - Conditional AddTodoPopover visibility
- `packages/web-client/src/components/todo_filters_navigation.tsx` - Spacing cleanup, whitespace-nowrap
- `packages/web-client/src/components/add_todo_popover.tsx` - Responsive button (icon-only on mobile)

Closes #451