### PR TITLE
feat: add blockedBy field for task dependencies

### DIFF
--- a/.changeset/blocked-by-task-dependencies.md
+++ b/.changeset/blocked-by-task-dependencies.md
@@ -1,0 +1,5 @@
+---
+"eddo-app": minor
+---
+
+Add blockedBy field for task dependencies with graph visualization and flyout UI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ This is a GTD-inspired todo and time tracking application built as a monorepo wi
 interface TodoAlpha3 {
   _id: string; // ISO timestamp of creation
   active: Record<string, string | null>; // Time tracking entries
+  blockedBy?: string[]; // Todo IDs that must complete first (use with gtd:blocked tag)
   completed: string | null;
   context: string; // GTD context
   description: string;

--- a/packages/core-shared/src/versions/todo_alpha3.ts
+++ b/packages/core-shared/src/versions/todo_alpha3.ts
@@ -38,6 +38,12 @@ export interface TodoAlpha3 extends Omit<TodoAlpha2, 'version'> {
    * Populated automatically after audit writes; eventual consistency.
    */
   auditLog?: string[];
+  /**
+   * Optional array of todo IDs that must complete before this task becomes actionable.
+   * Use with `gtd:blocked` tag to indicate internal task dependencies.
+   * Distinct from `gtd:waiting` which indicates external blocks (people, events).
+   */
+  blockedBy?: string[];
   version: 'alpha3';
 }
 

--- a/packages/mcp_server/src/tools/create-todo.ts
+++ b/packages/mcp_server/src/tools/create-todo.ts
@@ -94,6 +94,12 @@ export const createTodoParameters = z.object({
     .describe(
       'Optional parent todo ID for creating subtasks. References the _id of an existing todo to create a parent-child relationship.',
     ),
+  blockedBy: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Optional array of todo IDs that must complete before this task becomes actionable. Use with gtd:blocked tag for internal task dependencies. Distinct from gtd:waiting which is for external blocks.',
+    ),
   metadata: z
     .record(z.string(), z.union([z.string(), z.array(z.string())]))
     .optional()
@@ -178,6 +184,7 @@ function buildTodoDocument(args: CreateTodoArgs): Omit<TodoAlpha3, '_rev'> {
     externalId: args.externalId,
     link: args.link,
     parentId: args.parentId,
+    blockedBy: args.blockedBy,
     metadata: args.metadata,
     version: 'alpha3',
   };

--- a/packages/mcp_server/src/tools/update-todo.ts
+++ b/packages/mcp_server/src/tools/update-todo.ts
@@ -43,6 +43,13 @@ export const updateTodoParameters = z.object({
     .nullable()
     .optional()
     .describe('Updated parent todo ID (null to remove parent, making it a root todo)'),
+  blockedBy: z
+    .array(z.string())
+    .nullable()
+    .optional()
+    .describe(
+      'Updated array of todo IDs that block this task. Use with gtd:blocked tag. Set to null or empty array to remove all blockers.',
+    ),
   metadata: z
     .record(z.string(), z.union([z.string(), z.array(z.string())]))
     .optional()
@@ -107,6 +114,15 @@ function mergeUpdates(todo: TodoAlpha3, args: UpdateTodoArgs): TodoAlpha3 {
     link: pickValue(args.link, todo.link),
     externalId: pickValue(args.externalId, todo.externalId),
     parentId: pickValue(args.parentId, todo.parentId),
+    // null means "clear blockers" (convert to undefined for storage)
+    // undefined means "don't change" (keep existing)
+    // array means "set these blockers"
+    blockedBy:
+      args.blockedBy === null
+        ? undefined // Clear: store as undefined (no blockers)
+        : args.blockedBy !== undefined
+          ? args.blockedBy // Set: use provided array
+          : todo.blockedBy, // Keep: preserve existing
     metadata: pickValue(args.metadata, todo.metadata),
   };
 }

--- a/packages/web-client/src/components/todo_blocked_by_field.tsx
+++ b/packages/web-client/src/components/todo_blocked_by_field.tsx
@@ -1,0 +1,139 @@
+/**
+ * BlockedBy field component for editing task dependencies
+ */
+import { type Todo } from '@eddo/core-client';
+import { Label, TextInput } from 'flowbite-react';
+import { type FC, useState } from 'react';
+import { BiPlus, BiX } from 'react-icons/bi';
+
+import { useTodoById } from '../hooks/use_parent_child';
+
+interface BlockedByFieldProps {
+  todo: Todo;
+  onChange: (updater: (todo: Todo) => Todo) => void;
+}
+
+interface BlockerItemProps {
+  blockerId: string;
+  onRemove: () => void;
+}
+
+/** Displays a single blocker with its title and remove button */
+const BlockerItem: FC<BlockerItemProps> = ({ blockerId, onRemove }) => {
+  const { data: blockerTodo, isLoading } = useTodoById(blockerId);
+
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 dark:border-neutral-600 dark:bg-neutral-900/50">
+      <div className="min-w-0 flex-1">
+        {isLoading ? (
+          <span className="text-sm text-neutral-500">Loading...</span>
+        ) : blockerTodo ? (
+          <div>
+            <span className="text-sm text-neutral-900 dark:text-white">{blockerTodo.title}</span>
+            {blockerTodo.completed && (
+              <span className="ml-2 text-xs text-green-600 dark:text-green-400">✓ completed</span>
+            )}
+          </div>
+        ) : (
+          <span className="text-sm text-amber-600 dark:text-amber-400">Todo not found</span>
+        )}
+        <div className="truncate font-mono text-xs text-neutral-400 dark:text-neutral-500">
+          {blockerId}
+        </div>
+      </div>
+      <button
+        aria-label="Remove blocker"
+        className="rounded-lg p-1.5 text-neutral-500 hover:bg-neutral-200 hover:text-neutral-700 dark:hover:bg-neutral-700 dark:hover:text-neutral-300"
+        onClick={onRemove}
+        type="button"
+      >
+        <BiX size="1.2em" />
+      </button>
+    </div>
+  );
+};
+
+/** Hook for blockedBy field state management */
+function useBlockedByState(todo: Todo, onChange: (updater: (todo: Todo) => Todo) => void) {
+  const [newBlockerId, setNewBlockerId] = useState('');
+  const blockedBy = todo.blockedBy ?? [];
+
+  const handleAdd = () => {
+    const trimmed = newBlockerId.trim();
+    if (!trimmed || blockedBy.includes(trimmed)) return;
+    onChange((t) => ({ ...t, blockedBy: [...(t.blockedBy ?? []), trimmed] }));
+    setNewBlockerId('');
+  };
+
+  const handleRemove = (blockerId: string) => {
+    onChange((t) => ({
+      ...t,
+      blockedBy: (t.blockedBy ?? []).filter((id) => id !== blockerId),
+    }));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleAdd();
+    }
+  };
+
+  return { newBlockerId, setNewBlockerId, blockedBy, handleAdd, handleRemove, handleKeyDown };
+}
+
+/**
+ * Form field for editing blockedBy relationships.
+ * Allows adding/removing todo IDs that block this task.
+ */
+export const BlockedByField: FC<BlockedByFieldProps> = ({ todo, onChange }) => {
+  const state = useBlockedByState(todo, onChange);
+
+  return (
+    <div>
+      <div className="mb-2 block">
+        <Label htmlFor="eddoTodoBlockedBy">Blocked By</Label>
+      </div>
+
+      {state.blockedBy.length > 0 && (
+        <div className="mb-2 space-y-2">
+          {state.blockedBy.map((blockerId) => (
+            <BlockerItem
+              blockerId={blockerId}
+              key={blockerId}
+              onRemove={() => state.handleRemove(blockerId)}
+            />
+          ))}
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        <TextInput
+          aria-label="Add blocker ID"
+          className="flex-1"
+          id="eddoTodoBlockedBy"
+          onChange={(e) => state.setNewBlockerId(e.target.value)}
+          onKeyDown={state.handleKeyDown}
+          placeholder="Paste todo ID that blocks this task"
+          type="text"
+          value={state.newBlockerId}
+        />
+        <button
+          aria-label="Add blocker"
+          className="rounded-lg bg-neutral-100 p-2 text-neutral-600 hover:bg-neutral-200 hover:text-neutral-800 dark:bg-neutral-700 dark:text-neutral-400 dark:hover:bg-neutral-600 dark:hover:text-neutral-200"
+          disabled={!state.newBlockerId.trim()}
+          onClick={state.handleAdd}
+          type="button"
+        >
+          <BiPlus size="1.2em" />
+        </button>
+      </div>
+
+      {state.blockedBy.length === 0 && (
+        <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+          Add todo IDs that must complete before this task becomes actionable.
+        </p>
+      )}
+    </div>
+  );
+};

--- a/packages/web-client/src/components/todo_blocked_by_view.tsx
+++ b/packages/web-client/src/components/todo_blocked_by_view.tsx
@@ -1,0 +1,67 @@
+/**
+ * Read-only view component for blockedBy relationships
+ */
+import { type FC } from 'react';
+import { BiCheckCircle, BiCircle } from 'react-icons/bi';
+
+import { useTodoById } from '../hooks/use_parent_child';
+
+/** Label styling for field headers */
+const LABEL_CLASS =
+  'text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wide';
+
+/** Single blocker item in the view */
+const BlockerViewItem: FC<{ blockerId: string }> = ({ blockerId }) => {
+  const { data: blockerTodo, isLoading } = useTodoById(blockerId);
+
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 dark:border-neutral-600 dark:bg-neutral-900/50">
+      {blockerTodo?.completed ? (
+        <BiCheckCircle className="flex-shrink-0 text-green-500" size="1.2em" />
+      ) : (
+        <BiCircle className="flex-shrink-0 text-red-500" size="1.2em" />
+      )}
+      <div className="min-w-0 flex-1">
+        {isLoading ? (
+          <span className="text-sm text-neutral-500">Loading...</span>
+        ) : blockerTodo ? (
+          <span
+            className={`text-sm ${blockerTodo.completed ? 'text-neutral-500 line-through' : 'text-neutral-900 dark:text-white'}`}
+          >
+            {blockerTodo.title}
+          </span>
+        ) : (
+          <span className="text-sm text-amber-600 dark:text-amber-400">Todo not found</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+interface BlockedByViewProps {
+  blockedBy: string[] | undefined;
+}
+
+/**
+ * Read-only view of blockedBy relationships.
+ * Shows each blocker with completion status indicator.
+ */
+export const BlockedByView: FC<BlockedByViewProps> = ({ blockedBy }) => {
+  if (!blockedBy || blockedBy.length === 0) {
+    return null;
+  }
+
+  const label =
+    blockedBy.length === 1 ? 'Blocked By (1 task)' : `Blocked By (${blockedBy.length} tasks)`;
+
+  return (
+    <div>
+      <div className={LABEL_CLASS}>{label}</div>
+      <div className="mt-2 space-y-2">
+        {blockedBy.map((blockerId) => (
+          <BlockerViewItem blockerId={blockerId} key={blockerId} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/packages/web-client/src/components/todo_flyout.tsx
+++ b/packages/web-client/src/components/todo_flyout.tsx
@@ -10,6 +10,7 @@ import { BiEdit, BiShow } from 'react-icons/bi';
 import { useTags } from '../hooks/use_tags';
 import { useTodoFlyoutState } from '../hooks/use_todo_flyout_state';
 import { BTN_GHOST, BTN_PRIMARY, TRANSITION } from '../styles/interactive';
+import { BlockedByField } from './todo_blocked_by_field';
 import { ErrorDisplay } from './todo_edit_error';
 import {
   CompletedField,
@@ -112,6 +113,7 @@ const EditFormFields: FC<EditFormFieldsProps> = ({ todo, allTags, activeArray, o
     <LinkField onChange={onChange} todo={todo} />
     <ExternalIdField onChange={onChange} todo={todo} />
     <ParentIdField onChange={onChange} todo={todo} />
+    <BlockedByField onChange={onChange} todo={todo} />
     <RepeatField onChange={onChange} todo={todo} />
     <MetadataField onChange={onChange} todo={todo} />
     <NotesField onChange={onChange} todo={todo} />

--- a/packages/web-client/src/components/todo_graph_helpers.test.ts
+++ b/packages/web-client/src/components/todo_graph_helpers.test.ts
@@ -342,4 +342,68 @@ describe('createAllEdges', () => {
       expect(fileEdges).toHaveLength(1);
     });
   });
+
+  describe('blockedBy edges', () => {
+    it('creates edge from blocker to blocked todo', () => {
+      const todos = [
+        createMockTodo({ _id: 'blocker' }),
+        createMockTodo({ _id: 'blocked', blockedBy: ['blocker'] }),
+      ];
+
+      const edges = createAllEdges(todos, []);
+
+      const blockedEdges = edges.filter((e) => e.id.startsWith('blocked:'));
+      expect(blockedEdges).toHaveLength(1);
+      expect(blockedEdges[0].source).toBe('blocker');
+      expect(blockedEdges[0].target).toBe('blocked');
+    });
+
+    it('does not create edge when blocker is not in list', () => {
+      const todos = [createMockTodo({ _id: 'blocked', blockedBy: ['missing-blocker'] })];
+
+      const edges = createAllEdges(todos, []);
+
+      const blockedEdges = edges.filter((e) => e.id.startsWith('blocked:'));
+      expect(blockedEdges).toHaveLength(0);
+    });
+
+    it('creates multiple edges for multiple blockers', () => {
+      const todos = [
+        createMockTodo({ _id: 'blocker-1' }),
+        createMockTodo({ _id: 'blocker-2' }),
+        createMockTodo({ _id: 'blocked', blockedBy: ['blocker-1', 'blocker-2'] }),
+      ];
+
+      const edges = createAllEdges(todos, []);
+
+      const blockedEdges = edges.filter((e) => e.id.startsWith('blocked:'));
+      expect(blockedEdges).toHaveLength(2);
+    });
+
+    it('uses desaturated wine red style for incomplete blockers', () => {
+      const todos = [
+        createMockTodo({ _id: 'blocker', completed: null }),
+        createMockTodo({ _id: 'blocked', blockedBy: ['blocker'] }),
+      ];
+
+      const edges = createAllEdges(todos, []);
+
+      const blockedEdge = edges.find((e) => e.id.startsWith('blocked:'));
+      expect(blockedEdge?.animated).toBe(false);
+      expect(blockedEdge?.style?.stroke).toBe('#7f1d3d'); // desaturated rose
+    });
+
+    it('uses gray non-animated style for completed blockers', () => {
+      const todos = [
+        createMockTodo({ _id: 'blocker', completed: '2026-01-01T12:00:00.000Z' }),
+        createMockTodo({ _id: 'blocked', blockedBy: ['blocker'] }),
+      ];
+
+      const edges = createAllEdges(todos, []);
+
+      const blockedEdge = edges.find((e) => e.id.startsWith('blocked:'));
+      expect(blockedEdge?.animated).toBe(false);
+      expect(blockedEdge?.style?.stroke).toBe('#64748b'); // slate-500 (matches pending todo)
+    });
+  });
 });

--- a/packages/web-client/src/components/todo_graph_legend.tsx
+++ b/packages/web-client/src/components/todo_graph_legend.tsx
@@ -1,6 +1,6 @@
 /**
  * Legend component for the graph view.
- * Shows colored items for each node type with icons.
+ * Shows colored items for each node type with icons and edge explanations.
  */
 import { type FC } from 'react';
 import { HiDocumentText, HiUser } from 'react-icons/hi';
@@ -13,6 +13,13 @@ interface LegendItem {
   borderColor: string;
   Icon: typeof HiDocumentText;
   rounded?: boolean;
+}
+
+interface EdgeLegendItem {
+  label: string;
+  color: string;
+  dashed?: boolean;
+  animated?: boolean;
 }
 
 const LEGEND_ITEMS: LegendItem[] = [
@@ -34,6 +41,23 @@ const LEGEND_ITEMS: LegendItem[] = [
     borderColor: 'border-sky-400',
     Icon: HiUser,
     rounded: true,
+  },
+];
+
+const EDGE_LEGEND_ITEMS: EdgeLegendItem[] = [
+  {
+    label: 'Parent → Child',
+    color: '#64748b', // slate-500 (matches pending todo)
+  },
+  {
+    label: 'Blocker',
+    color: '#7f1d3d', // desaturated rose
+    dashed: true,
+  },
+  {
+    label: 'Agent Session',
+    color: '#7c3aed', // violet-600
+    dashed: true,
   },
 ];
 
@@ -69,25 +93,70 @@ const LegendItemRow: FC<{ item: LegendItem }> = ({ item }) => {
       >
         <Icon className="h-3 w-3 text-white" />
       </div>
-      <span className="text-xs text-neutral-300">{label}</span>
+      <span className="text-xs text-neutral-700 dark:text-neutral-300">{label}</span>
     </div>
   );
 };
 
-/** Graph legend showing all node types */
+/** Single edge legend item with line sample and label */
+const EdgeLegendRow: FC<{ item: EdgeLegendItem }> = ({ item }) => {
+  const { label, color, dashed, animated } = item;
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex h-5 w-5 items-center justify-center">
+        <svg className="h-4 w-5" viewBox="0 0 20 16">
+          <line
+            stroke={color}
+            strokeDasharray={dashed ? '4,3' : undefined}
+            strokeWidth="2"
+            x1="0"
+            x2="20"
+            y1="8"
+            y2="8"
+          >
+            {animated && (
+              <animate
+                attributeName="stroke-dashoffset"
+                dur="0.5s"
+                from="0"
+                repeatCount="indefinite"
+                to="7"
+              />
+            )}
+          </line>
+        </svg>
+      </div>
+      <span className="text-xs text-neutral-700 dark:text-neutral-300">{label}</span>
+    </div>
+  );
+};
+
+/** Graph legend showing all node and edge types */
 export const GraphLegend: FC = () => (
-  <div className="absolute right-4 bottom-4 z-10 rounded-lg border border-neutral-700 bg-neutral-800/90 px-3 py-2 shadow-lg backdrop-blur-sm">
-    <div className="mb-1.5 text-[10px] font-medium tracking-wide text-neutral-400 uppercase">
-      Legend
+  <div className="absolute right-4 bottom-4 z-10 rounded-lg border border-neutral-300 bg-white/90 px-3 py-2 shadow-lg backdrop-blur-sm dark:border-neutral-700 dark:bg-neutral-800/90">
+    {/* Nodes section */}
+    <div className="mb-1.5 text-[10px] font-medium tracking-wide text-neutral-500 uppercase dark:text-neutral-400">
+      Nodes
     </div>
     <div className="flex flex-col gap-1.5">
       {/* Split todo icon for pending/completed */}
       <div className="flex items-center gap-2">
         <SplitTodoIcon />
-        <span className="text-xs text-neutral-300">Todo</span>
+        <span className="text-xs text-neutral-700 dark:text-neutral-300">Todo</span>
       </div>
       {LEGEND_ITEMS.map((item) => (
         <LegendItemRow item={item} key={item.label} />
+      ))}
+    </div>
+
+    {/* Edges section */}
+    <div className="mt-2.5 mb-1.5 border-t border-neutral-300 pt-2 text-[10px] font-medium tracking-wide text-neutral-500 uppercase dark:border-neutral-700 dark:text-neutral-400">
+      Edges
+    </div>
+    <div className="flex flex-col gap-1.5">
+      {EDGE_LEGEND_ITEMS.map((item) => (
+        <EdgeLegendRow item={item} key={item.label} />
       ))}
     </div>
   </div>

--- a/packages/web-client/src/components/todo_graph_renderer.tsx
+++ b/packages/web-client/src/components/todo_graph_renderer.tsx
@@ -42,6 +42,21 @@ const applyHighlight = (nodes: Node[], highlightedId: string | null): Node[] =>
     return { ...node, data: { ...node.data, isHighlighted: node.id === highlightedId } };
   });
 
+/** Loading spinner shown during layout calculation */
+const LayoutingSpinner: FC = () => (
+  <div className="flex h-[calc(100vh-200px)] w-full items-center justify-center">
+    <Spinner aria-label="Calculating layout" size="lg" />
+    <span className="ml-3 text-neutral-600 dark:text-neutral-400">Arranging nodes...</span>
+  </div>
+);
+
+/** Controls styling for light/dark mode */
+const CONTROLS_CLASS =
+  '!border-neutral-300 !bg-white !shadow-lg dark:!border-neutral-700 dark:!bg-neutral-800 ' +
+  '[&>button]:!border-neutral-200 [&>button]:!bg-neutral-50 [&>button]:!fill-neutral-600 ' +
+  'dark:[&>button]:!border-neutral-600 dark:[&>button]:!bg-neutral-700 dark:[&>button]:!fill-neutral-300 ' +
+  '[&>button:hover]:!bg-neutral-100 dark:[&>button:hover]:!bg-neutral-600';
+
 export interface GraphRendererProps {
   nodes: Node[];
   edges: Edge[];
@@ -74,14 +89,7 @@ export const GraphRenderer: FC<GraphRendererProps> = ({
     }
   }, [layoutedNodes, isLayouting, fitView]);
 
-  if (isLayouting) {
-    return (
-      <div className="flex h-[calc(100vh-200px)] w-full items-center justify-center">
-        <Spinner aria-label="Calculating layout" size="lg" />
-        <span className="ml-3 text-neutral-600 dark:text-neutral-400">Arranging nodes...</span>
-      </div>
-    );
-  }
+  if (isLayouting) return <LayoutingSpinner />;
 
   return (
     <ReactFlow
@@ -97,8 +105,13 @@ export const GraphRenderer: FC<GraphRendererProps> = ({
       onNodesChange={onNodesChange}
       proOptions={{ hideAttribution: true }}
     >
-      <Background color="#94a3b8" gap={16} size={1} />
-      <Controls className="!border-neutral-700 !bg-neutral-800 !shadow-lg [&>button]:!border-neutral-600 [&>button]:!bg-neutral-700 [&>button]:!fill-neutral-300 [&>button:hover]:!bg-neutral-600" />
+      <Background
+        className="!bg-neutral-100 dark:!bg-neutral-800"
+        color="#94a3b8"
+        gap={16}
+        size={1}
+      />
+      <Controls className={CONTROLS_CLASS} />
       <GraphLegend />
     </ReactFlow>
   );

--- a/packages/web-client/src/components/todo_view_fields.tsx
+++ b/packages/web-client/src/components/todo_view_fields.tsx
@@ -16,6 +16,7 @@ import { useChildTodos, useParentTodo } from '../hooks/use_parent_child';
 import { TEXT_LINK } from '../styles/interactive';
 import { CopyIdButton } from './copy_id_button';
 import { TagDisplay } from './tag_display';
+import { BlockedByView } from './todo_blocked_by_view';
 import { MetadataView } from './todo_metadata_view';
 
 interface TodoViewFieldsProps {
@@ -318,6 +319,7 @@ export const TodoViewFields: FC<TodoViewFieldsProps> = ({ todo }) => (
   <div className="flex flex-col gap-6">
     <TitleView todo={todo} />
     <ParentView parentId={todo.parentId} />
+    <BlockedByView blockedBy={todo.blockedBy} />
     <DescriptionView description={todo.description} />
 
     <div className="grid grid-cols-2 gap-4">

--- a/packages/web-client/src/hooks/use_parent_child.ts
+++ b/packages/web-client/src/hooks/use_parent_child.ts
@@ -80,3 +80,23 @@ export function useChildCount(parentId: string | null | undefined, enabled = tru
     enabled: !!safeDb && !!parentId && enabled,
   });
 }
+
+/**
+ * Fetches a todo by ID (generic version for any relationship lookup)
+ * @param todoId - The _id of the todo to fetch
+ * @param enabled - Whether the query should run
+ */
+export function useTodoById(todoId: string | null | undefined, enabled = true) {
+  const { safeDb } = usePouchDb();
+
+  return useQuery({
+    queryKey: ['todos', 'byId', todoId],
+    queryFn: async () => {
+      if (!todoId) return null;
+
+      const todo = await safeDb.safeGet<Todo>(todoId);
+      return todo;
+    },
+    enabled: !!safeDb && !!todoId && enabled,
+  });
+}


### PR DESCRIPTION
## Summary
Add GTD-native support for task dependencies with a new `blockedBy` field and graph visualization.

## Changes
- Add `blockedBy?: string[]` field to TodoAlpha3 for internal task dependencies
- Add `-b/--blocked-by` flag to CLI for setting blockers
- Filter blocked todos from `next` command when blockers incomplete
- Visualize blocking relationships in graph view (wine red dashed edges)
- Add "Edges" section to graph legend explaining all edge types
- Add blockedBy field to view/edit flyout with add/remove UI
- Light/dark mode support for graph controls and legend

## GTD Concept
- `gtd:waiting` = blocked on **external** (person, event)
- `gtd:blocked` = blocked on **internal** (another task)

Closes #455