### PR TITLE
refactor(web-client): optimize table queries with MapReduce views

### DIFF
--- a/.changeset/mapreduce-views-optimization.md
+++ b/.changeset/mapreduce-views-optimization.md
@@ -1,0 +1,5 @@
+---
+"eddo-app": patch
+---
+
+Add MapReduce views for O(1) tag/context aggregation and batch subtask counts

--- a/packages/core-shared/src/api/database-structures.ts
+++ b/packages/core-shared/src/api/database-structures.ts
@@ -91,8 +91,23 @@ export const DESIGN_DOCS: DesignDocument[] = [
         map: `function(doc) {
           if (doc.version === 'alpha3' && doc.tags && Array.isArray(doc.tags) && doc.tags.length > 0) {
             for (var i = 0; i < doc.tags.length; i++) {
-              emit(doc.tags[i], 1);
+              var tag = (doc.tags[i] || '').trim();
+              if (tag) emit(tag, 1);
             }
+          }
+        }`,
+        reduce: '_count',
+      },
+    },
+  },
+  {
+    _id: '_design/contexts',
+    views: {
+      by_context: {
+        map: `function(doc) {
+          if (doc.version === 'alpha3' && doc.context) {
+            var ctx = doc.context.trim();
+            if (ctx) emit(ctx, 1);
           }
         }`,
         reduce: '_count',

--- a/packages/web-client/src/components/todo_table_content.tsx
+++ b/packages/web-client/src/components/todo_table_content.tsx
@@ -1,0 +1,151 @@
+/**
+ * Content components for TodoTable - handles rendering of table structure
+ */
+import type { Todo } from '@eddo/core-client';
+import { Spinner } from 'flowbite-react';
+import { type FC } from 'react';
+
+import { type SubtaskCount } from '../hooks/use_parent_child';
+import { BulkDueDatePopover } from './bulk_due_date_popover';
+import { FormattedMessage } from './formatted_message';
+import {
+  getColumnLabel,
+  getColumnWidthClass,
+  reorderColumnsWithStatusFirst,
+} from './todo_table_helpers';
+import { TodoRow } from './todo_table_row';
+
+export const LoadingSpinner: FC = () => (
+  <div
+    aria-label="Loading todos"
+    className="flex min-h-64 items-center justify-center bg-neutral-50 dark:bg-neutral-800"
+    role="status"
+  >
+    <Spinner aria-label="Loading" size="lg" />
+    <span className="ml-3 text-neutral-600 dark:text-neutral-400">Loading todos...</span>
+  </div>
+);
+
+export interface TodoTableContentProps {
+  groupedByContext: Array<[string, Todo[]]>;
+  durationByContext: Record<string, string>;
+  todoDurations: Map<string, number>;
+  subtaskCounts: Map<string, SubtaskCount>;
+  selectedColumns: string[];
+  timeTrackingActive: string[];
+}
+
+export const TodoTableContent: FC<TodoTableContentProps> = ({
+  groupedByContext,
+  durationByContext,
+  todoDurations,
+  subtaskCounts,
+  selectedColumns,
+  timeTrackingActive,
+}) => (
+  <div className="overflow-x-auto py-2">
+    {groupedByContext.map(([context, contextTodos]) => (
+      <ContextGroup
+        context={context}
+        contextTodos={contextTodos}
+        durationByContext={durationByContext}
+        key={context}
+        selectedColumns={selectedColumns}
+        subtaskCounts={subtaskCounts}
+        timeTrackingActive={timeTrackingActive}
+        todoDurations={todoDurations}
+      />
+    ))}
+  </div>
+);
+
+interface ContextGroupProps {
+  context: string;
+  contextTodos: Todo[];
+  durationByContext: Record<string, string>;
+  todoDurations: Map<string, number>;
+  subtaskCounts: Map<string, SubtaskCount>;
+  selectedColumns: string[];
+  timeTrackingActive: string[];
+}
+
+const ContextGroup: FC<ContextGroupProps> = ({
+  context,
+  contextTodos,
+  durationByContext,
+  todoDurations,
+  subtaskCounts,
+  selectedColumns,
+  timeTrackingActive,
+}) => (
+  <div className="mb-4">
+    <ContextHeader context={context} duration={durationByContext[context]} />
+    <div className="overflow-hidden rounded-lg border border-neutral-200 bg-white dark:border-neutral-700 dark:bg-neutral-800">
+      <table className="min-w-full divide-y divide-neutral-200 dark:divide-neutral-700">
+        <TableHeader contextTodos={contextTodos} selectedColumns={selectedColumns} />
+        <tbody className="divide-y divide-neutral-200 bg-white dark:divide-neutral-700 dark:bg-neutral-800">
+          {contextTodos.map((todo) => (
+            <TodoRow
+              key={`${todo._id}-${todo._rev}`}
+              selectedColumns={selectedColumns}
+              subtaskCount={subtaskCounts.get(todo._id)}
+              timeTrackingActive={timeTrackingActive.length > 0}
+              todo={todo}
+              todoDuration={todoDurations.get(todo._id) ?? 0}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  </div>
+);
+
+const ContextHeader: FC<{ context: string; duration: string }> = ({ context, duration }) => (
+  <div className="mb-1 flex items-center justify-between">
+    <h3 className="text-xs font-semibold tracking-wide text-neutral-700 uppercase dark:text-neutral-300">
+      <FormattedMessage message={context} />
+    </h3>
+    <span className="text-xs text-neutral-500 dark:text-neutral-400">{duration}</span>
+  </div>
+);
+
+interface TableHeaderProps {
+  selectedColumns: string[];
+  contextTodos: readonly Todo[];
+}
+
+/** Render column header content, with bulk action popover for due date column */
+const ColumnHeaderContent: FC<{ columnId: string; contextTodos: readonly Todo[] }> = ({
+  columnId,
+  contextTodos,
+}) => {
+  const label = getColumnLabel(columnId);
+
+  if (columnId === 'due') {
+    return <BulkDueDatePopover todos={contextTodos}>{label}</BulkDueDatePopover>;
+  }
+
+  return <>{label}</>;
+};
+
+const TableHeader: FC<TableHeaderProps> = ({ selectedColumns, contextTodos }) => (
+  <thead className="bg-neutral-50 dark:bg-neutral-700">
+    <tr>
+      {reorderColumnsWithStatusFirst(selectedColumns).map((columnId) => (
+        <th
+          className={`px-2 py-1 text-left text-xs font-medium tracking-wide text-neutral-500 uppercase dark:text-neutral-400 ${getColumnWidthClass(columnId)}`}
+          key={columnId}
+          scope="col"
+        >
+          <ColumnHeaderContent columnId={columnId} contextTodos={contextTodos} />
+        </th>
+      ))}
+      <th
+        className="w-24 px-2 py-1 text-right text-xs font-medium tracking-wide text-neutral-500 uppercase dark:text-neutral-400"
+        scope="col"
+      >
+        Actions
+      </th>
+    </tr>
+  </thead>
+);

--- a/packages/web-client/src/hooks/use_eddo_contexts.ts
+++ b/packages/web-client/src/hooks/use_eddo_contexts.ts
@@ -1,65 +1,68 @@
 /**
  * React hook for context management and filtering.
- * Uses Mango query with context index for efficient context extraction.
+ * Uses MapReduce view for efficient aggregation, wrapped in TanStack Query for caching.
  */
-import { type Todo } from '@eddo/core-client';
-import { useEffect, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
 
 import { usePouchDb } from '../pouch_db';
 import { useDatabaseChanges } from './use_database_changes';
 
 export interface EddoContextsState {
+  /** All unique contexts from existing todos */
   allContexts: string[];
+  /** Whether contexts are currently being loaded */
   isLoading: boolean;
+  /** Error if contexts failed to load */
   error: Error | null;
+}
+
+/** Result row from MapReduce query with group=true */
+interface ViewRow {
+  key: string;
+  value: number;
 }
 
 /**
  * Hook for fetching all existing contexts for filtering.
- * Uses Mango query with fields projection to only fetch context, not full documents.
+ * Uses MapReduce view (_design/contexts/by_context) with reduce for O(1) aggregation.
+ * Results are cached via TanStack Query and invalidated on database changes.
  */
 export const useEddoContexts = (): EddoContextsState => {
-  const { safeDb } = usePouchDb();
+  const { rawDb } = usePouchDb();
   const { changeCount } = useDatabaseChanges();
-  const [allContexts, setAllContexts] = useState<string[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
+  const queryClient = useQueryClient();
 
+  // Invalidate contexts query when database changes
   useEffect(() => {
-    const fetchContexts = async () => {
-      try {
-        setIsLoading(true);
-        setError(null);
+    if (changeCount > 0) {
+      queryClient.invalidateQueries({ queryKey: ['contexts'] });
+    }
+  }, [changeCount, queryClient]);
 
-        // Query alpha3 documents, fetching only the context field
-        const todos = await safeDb.safeFind<Pick<Todo, 'context'>>(
-          { version: 'alpha3' },
-          { fields: ['context'] },
-        );
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['contexts'],
+    queryFn: async () => {
+      // Query MapReduce view with reduce to get unique contexts
+      // group=true returns one row per unique context with count
+      const result = await rawDb!.query('contexts/by_context', {
+        group: true,
+        reduce: true,
+      });
 
-        // Extract unique contexts from results
-        const contextSet = new Set<string>();
-        for (const todo of todos) {
-          if (todo.context && todo.context.trim()) {
-            contextSet.add(todo.context.trim());
-          }
-        }
-
-        setAllContexts(Array.from(contextSet).sort());
-      } catch (err) {
-        console.error('Failed to fetch contexts:', err);
-        setError(err as Error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchContexts();
-  }, [safeDb, changeCount]);
+      // Extract just the context names (keys), sorted alphabetically
+      return (result.rows as ViewRow[])
+        .map((row) => row.key)
+        .filter((key) => key && key.trim())
+        .sort();
+    },
+    enabled: !!rawDb,
+    staleTime: Infinity, // Contexts don't change often, rely on invalidation
+  });
 
   return {
-    allContexts,
+    allContexts: data ?? [],
     isLoading,
-    error,
+    error: error as Error | null,
   };
 };

--- a/packages/web-client/src/hooks/use_tags.ts
+++ b/packages/web-client/src/hooks/use_tags.ts
@@ -1,9 +1,9 @@
 /**
  * React hook for tag management and autocomplete.
- * Uses Mango query with tags index for efficient tag extraction.
+ * Uses MapReduce view for efficient aggregation, wrapped in TanStack Query for caching.
  */
-import { type Todo } from '@eddo/core-client';
-import { useEffect, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
 
 import { usePouchDb } from '../pouch_db';
 import { useDatabaseChanges } from './use_database_changes';
@@ -17,53 +17,52 @@ export interface TagsState {
   error: Error | null;
 }
 
+/** Result row from MapReduce query with group=true */
+interface ViewRow {
+  key: string;
+  value: number;
+}
+
 /**
  * Hook for fetching all existing tags for autocomplete.
- * Uses Mango query with fields projection to only fetch tags, not full documents.
+ * Uses MapReduce view (_design/tags/by_tag) with reduce for O(1) aggregation.
+ * Results are cached via TanStack Query and invalidated on database changes.
  */
 export const useTags = (): TagsState => {
-  const { safeDb } = usePouchDb();
+  const { rawDb } = usePouchDb();
   const { changeCount } = useDatabaseChanges();
-  const [allTags, setAllTags] = useState<string[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
+  const queryClient = useQueryClient();
 
+  // Invalidate tags query when database changes
   useEffect(() => {
-    const fetchTags = async () => {
-      try {
-        setIsLoading(true);
-        setError(null);
+    if (changeCount > 0) {
+      queryClient.invalidateQueries({ queryKey: ['tags'] });
+    }
+  }, [changeCount, queryClient]);
 
-        // Query alpha3 documents, fetching only the tags field
-        // PouchDB-find doesn't support $gt: [] for arrays, so we filter client-side
-        const todos = await safeDb.safeFind<Pick<Todo, 'tags'>>(
-          { version: 'alpha3' },
-          { fields: ['tags'] },
-        );
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['tags'],
+    queryFn: async () => {
+      // Query MapReduce view with reduce to get unique tags
+      // group=true returns one row per unique tag with count
+      const result = await rawDb!.query('tags/by_tag', {
+        group: true,
+        reduce: true,
+      });
 
-        // Extract unique tags from results, filtering out malformed data
-        const tagSet = new Set<string>();
-        const validTags = todos
-          .filter((todo) => Array.isArray(todo.tags))
-          .flatMap((todo) => todo.tags!)
-          .filter((tag) => tag && tag.trim());
-        validTags.forEach((tag) => tagSet.add(tag.trim()));
-
-        setAllTags(Array.from(tagSet).sort());
-      } catch (err) {
-        console.error('Failed to fetch tags:', err);
-        setError(err as Error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchTags();
-  }, [safeDb, changeCount]);
+      // Extract just the tag names (keys), sorted alphabetically
+      return (result.rows as ViewRow[])
+        .map((row) => row.key)
+        .filter((key) => key && key.trim())
+        .sort();
+    },
+    enabled: !!rawDb,
+    staleTime: Infinity, // Tags don't change often, rely on invalidation
+  });
 
   return {
-    allTags,
+    allTags: data ?? [],
     isLoading,
-    error,
+    error: error as Error | null,
   };
 };


### PR DESCRIPTION
## Summary

Optimize web-client database queries by replacing Mango queries with MapReduce views for O(1) aggregation.

## Changes

- Add `_design/contexts` MapReduce view with `_count` reduce
- Update `_design/tags` view to trim whitespace in map function
- Refactor `useTags` and `useEddoContexts` to use `rawDb.query()` with `group:true`
- Add `useSubtaskCountsForParents` hook for batch subtask counting (avoids N+1 queries)
- Extract `TodoTableContent` component from `todo_table.tsx`
- Pass pre-computed subtask counts through component tree
- Update test setup with required design documents

## Performance Impact

**Before:** Mango query fetched up to 10K docs, O(n) client-side aggregation
**After:** Pre-computed views with `_count` reduce, O(1) query returning ~50 unique keys