### PR TITLE
fix: complete button in table-view and table layout on mobile

### DIFF
--- a/.changeset/fix-table-complete-button.md
+++ b/.changeset/fix-table-complete-button.md
@@ -1,0 +1,5 @@
+---
+"eddo-app": patch
+---
+
+Fix complete button in table-view and improve table layout on narrow screens

--- a/packages/web-client/src/components/todo_table_child_row.tsx
+++ b/packages/web-client/src/components/todo_table_child_row.tsx
@@ -32,9 +32,6 @@ const buildRowData = (
   todo,
   duration,
   subtaskCount,
-  isUpdating: false,
-  error: null,
-  onToggleCheckbox: () => {},
 });
 
 /** Maximum nesting depth to prevent infinite recursion */

--- a/packages/web-client/src/components/todo_table_context_group.tsx
+++ b/packages/web-client/src/components/todo_table_context_group.tsx
@@ -38,9 +38,6 @@ const useRowData = (
         todo,
         duration: todoDurations.get(todo._id) ?? 0,
         subtaskCount: subtaskCounts.get(todo._id),
-        isUpdating: false,
-        error: null,
-        onToggleCheckbox: () => {},
       })),
     [contextTodos, todoDurations, subtaskCounts],
   );
@@ -94,7 +91,7 @@ export const ContextGroup: FC<ContextGroupProps> = (props) => {
         containerRef={containerRef}
         useVirtualization={rows.length > VIRTUALIZATION_THRESHOLD}
       >
-        <table className="w-full table-fixed divide-y divide-neutral-200 dark:divide-neutral-700">
+        <table className="w-full min-w-[800px] table-fixed divide-y divide-neutral-200 dark:divide-neutral-700">
           <TableHead contextTodos={contextTodos} table={table} />
           <ExpandableRows
             childrenByParent={childrenByParent}
@@ -131,9 +128,9 @@ interface TableContainerProps {
 
 const TableContainer: FC<TableContainerProps> = ({ containerRef, useVirtualization, children }) => (
   <div
-    className="overflow-hidden rounded-lg border border-neutral-200 bg-white dark:border-neutral-700 dark:bg-neutral-800"
+    className="overflow-x-auto rounded-lg border border-neutral-200 bg-white dark:border-neutral-700 dark:bg-neutral-800"
     ref={containerRef}
-    style={{ maxHeight: useVirtualization ? '600px' : undefined, overflow: 'auto' }}
+    style={{ maxHeight: useVirtualization ? '600px' : undefined, overflowY: 'auto' }}
   >
     {children}
   </div>

--- a/packages/web-client/src/hooks/use_audited_todo_mutations.ts
+++ b/packages/web-client/src/hooks/use_audited_todo_mutations.ts
@@ -241,6 +241,7 @@ export function useAuditedSaveTodoMutation() {
  */
 export function useAuditedToggleCompletionMutation() {
   const { safeDb } = usePouchDb();
+  const queryClient = useQueryClient();
   const auditedMutation = useAuditedTodoMutation();
 
   return useMutation<Todo, Error, Todo>({
@@ -267,6 +268,11 @@ export function useAuditedToggleCompletionMutation() {
           return result;
         },
       );
+    },
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['todos'] });
+      queryClient.invalidateQueries({ queryKey: ['activities'] });
     },
   });
 }


### PR DESCRIPTION
## Summary

Fixes the complete button functionality in table-view and improves table layout on narrow screens.

## Changes

- **StatusCell refactored**: Uses `useAuditedToggleCompletionMutation` hook directly instead of receiving callback props
- **Query invalidation**: Adds `onSuccess` handler to invalidate `todos` and `activities` queries after completion toggle
- **TodoRowData simplified**: Removes `isUpdating`, `error`, and `onToggleCheckbox` props from row data interface
- **Table layout**: Adds `min-w-[800px]` and horizontal scroll support for narrow viewports