### PR TITLE
fix: use UTC day ranges for briefing recap

### DIFF
--- a/.changeset/fix-recap-utc-date-ranges.md
+++ b/.changeset/fix-recap-utc-date-ranges.md
@@ -1,0 +1,5 @@
+---
+"eddo-app": patch
+---
+
+Fix briefing and recap date ranges to use UTC day boundaries.

--- a/packages/mcp_server/src/tools/date-range.test.ts
+++ b/packages/mcp_server/src/tools/date-range.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { getUtcDateRange } from './date-range.js';
+
+describe('getUtcDateRange', () => {
+  it('returns UTC day boundaries for a reference instant', () => {
+    const result = getUtcDateRange(new Date('2026-01-02T12:34:56.789Z'));
+
+    expect(result).toEqual({
+      todayStart: '2026-01-02T00:00:00.000Z',
+      todayEnd: '2026-01-02T23:59:59.999Z',
+      todayDate: '2026-01-02',
+    });
+  });
+
+  it('does not shift the range for offset timestamps near midnight', () => {
+    const result = getUtcDateRange(new Date('2026-01-02T00:30:00+02:00'));
+
+    expect(result).toEqual({
+      todayStart: '2026-01-01T00:00:00.000Z',
+      todayEnd: '2026-01-01T23:59:59.999Z',
+      todayDate: '2026-01-01',
+    });
+  });
+});

--- a/packages/mcp_server/src/tools/date-range.ts
+++ b/packages/mcp_server/src/tools/date-range.ts
@@ -1,0 +1,24 @@
+/** Date range for current UTC day queries */
+export interface DateRange {
+  todayStart: string;
+  todayEnd: string;
+  todayDate: string;
+}
+
+/**
+ * Returns UTC day boundaries for a reference instant.
+ *
+ * @param now - Reference instant.
+ * @return UTC date range metadata.
+ */
+export function getUtcDateRange(now: Date = new Date()): DateRange {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  const date = now.getUTCDate();
+
+  return {
+    todayStart: new Date(Date.UTC(year, month, date, 0, 0, 0, 0)).toISOString(),
+    todayEnd: new Date(Date.UTC(year, month, date, 23, 59, 59, 999)).toISOString(),
+    todayDate: now.toISOString().split('T')[0] ?? '1970-01-01',
+  };
+}

--- a/packages/mcp_server/src/tools/get-briefing-data.ts
+++ b/packages/mcp_server/src/tools/get-briefing-data.ts
@@ -5,6 +5,7 @@ import type { TodoAlpha3 } from '@eddo/core-server';
 import type { MangoQuery } from 'nano';
 import { z } from 'zod';
 
+import { getUtcDateRange, type DateRange } from './date-range.js';
 import { createErrorResponse, createSuccessResponse } from './response-helpers.js';
 import type { GetUserDb, ToolContext } from './types.js';
 
@@ -27,13 +28,6 @@ export const getBriefingDataParameters = z
   .describe('No parameters required - returns all briefing-relevant data for the current date');
 
 export type GetBriefingDataArgs = z.infer<typeof getBriefingDataParameters>;
-
-/** Date range for queries */
-interface DateRange {
-  todayStart: string;
-  todayEnd: string;
-  todayDate: string;
-}
 
 /** Structure for briefing data response */
 interface BriefingData {
@@ -66,23 +60,6 @@ interface QueryResults {
   waitingFor: TodoAlpha3[];
   calendarToday: TodoAlpha3[];
   activeTimeTracking: Array<TodoAlpha3 & { activeSessionCount: number }>;
-}
-
-/**
- * Gets today's date range in ISO format
- */
-function getDateRange(): DateRange {
-  const now = new Date();
-  const start = new Date(now);
-  start.setHours(0, 0, 0, 0);
-  const end = new Date(now);
-  end.setHours(23, 59, 59, 999);
-
-  return {
-    todayStart: start.toISOString(),
-    todayEnd: end.toISOString(),
-    todayDate: now.toISOString().split('T')[0],
-  };
 }
 
 /**
@@ -253,7 +230,7 @@ export async function executeGetBriefingData(
 ): Promise<string> {
   const db = getUserDb(context);
   const startTime = Date.now();
-  const dateRange = getDateRange();
+  const dateRange = getUtcDateRange();
 
   context.log.info('Getting briefing data for user', { userId: context.session?.userId });
 

--- a/packages/mcp_server/src/tools/get-recap-data.ts
+++ b/packages/mcp_server/src/tools/get-recap-data.ts
@@ -5,6 +5,7 @@ import type { TodoAlpha3 } from '@eddo/core-server';
 import type { MangoQuery } from 'nano';
 import { z } from 'zod';
 
+import { getUtcDateRange, type DateRange } from './date-range.js';
 import { createErrorResponse, createSuccessResponse } from './response-helpers.js';
 import type { GetUserDb, ToolContext } from './types.js';
 
@@ -24,13 +25,6 @@ export const getRecapDataParameters = z
   .describe('No parameters required - returns all recap-relevant data for the current date');
 
 export type GetRecapDataArgs = z.infer<typeof getRecapDataParameters>;
-
-/** Date range for queries */
-interface DateRange {
-  todayStart: string;
-  todayEnd: string;
-  todayDate: string;
-}
 
 /** Structure for recap data response */
 interface RecapData {
@@ -54,23 +48,6 @@ interface QueryResults {
   completedToday: TodoAlpha3[];
   activeTimeTracking: Array<TodoAlpha3 & { activeSessionCount: number }>;
   upcomingNextActions: TodoAlpha3[];
-}
-
-/**
- * Gets today's date range in ISO format
- */
-function getDateRange(): DateRange {
-  const now = new Date();
-  const start = new Date(now);
-  start.setHours(0, 0, 0, 0);
-  const end = new Date(now);
-  end.setHours(23, 59, 59, 999);
-
-  return {
-    todayStart: start.toISOString(),
-    todayEnd: end.toISOString(),
-    todayDate: now.toISOString().split('T')[0],
-  };
 }
 
 /**
@@ -208,7 +185,7 @@ export async function executeGetRecapData(
 ): Promise<string> {
   const db = getUserDb(context);
   const startTime = Date.now();
-  const dateRange = getDateRange();
+  const dateRange = getUtcDateRange();
 
   context.log.info('Getting recap data for user', { userId: context.session?.userId });
 


### PR DESCRIPTION
Fixes #340.

## Summary
- Extract UTC day range calculation for MCP tools.
- Apply UTC boundaries to briefing and recap queries.
- Add coverage for offset timestamps near midnight.

## Tests
- Pre-commit: tsc:check, lint, lint:format