### PR TITLE
fix: honor timezones in daily reports

### DIFF
--- a/.changeset/timezone-daily-reports.md
+++ b/.changeset/timezone-daily-reports.md
@@ -1,0 +1,5 @@
+---
+"eddo-app": patch
+---
+
+Honor user timezones in daily recap prompts and activity reports.

--- a/packages/telegram_bot/src/bot/commands/briefing.ts
+++ b/packages/telegram_bot/src/bot/commands/briefing.ts
@@ -151,7 +151,7 @@ async function generateBriefingRecap(ctx: Context, user: TelegramUser): Promise<
     });
 
     if (ctx.message) {
-      ctx.message.text = getRecapRequestMessage();
+      ctx.message.text = getRecapRequestMessage(user.preferences?.timezone);
     }
 
     await handleMessage(ctx as BotContext);

--- a/packages/telegram_bot/src/constants/briefing.ts
+++ b/packages/telegram_bot/src/constants/briefing.ts
@@ -1,3 +1,5 @@
+import { formatDateInTimeZone, normalizeTimeZone } from '@eddo/core-server';
+
 /**
  * Constants for daily briefing and recap functionality
  */
@@ -29,12 +31,14 @@ IMPORTANT: Start your briefing response with exactly this marker on its own line
 export const RECAP_CONTENT_MARKER = '---RECAP-START---';
 
 /**
- * Generates a recap request message
- * Uses getRecapData tool for efficient single-call data retrieval
+ * Generates a recap request message.
+ * Uses getRecapData tool for efficient single-call data retrieval.
+ *
+ * @param timeZone User timezone.
+ * @return Recap prompt.
  */
-export function getRecapRequestMessage(): string {
-  const now = new Date();
-  const dateStr = now.toISOString().split('T')[0];
+export function getRecapRequestMessage(timeZone?: string): string {
+  const dateStr = formatDateInTimeZone(new Date(), normalizeTimeZone(timeZone));
 
   return `Generate an INSIGHTFUL daily recap with SPECIFIC completed tasks. Today is ${dateStr}. Call the getRecapData tool to get all recap data in one call. This returns:
 - completedToday: Todos completed today with timestamps

--- a/packages/telegram_bot/src/scheduler/daily-briefing.ts
+++ b/packages/telegram_bot/src/scheduler/daily-briefing.ts
@@ -283,7 +283,7 @@ export class DailyBriefingScheduler {
 
     const result = await executeAgentForUser(
       user,
-      getRecapRequestMessage(),
+      getRecapRequestMessage(user.preferences?.timezone),
       RECAP_CONTENT_MARKER,
       'recap',
     );

--- a/packages/web-client/src/components/todo_board_state.ts
+++ b/packages/web-client/src/components/todo_board_state.ts
@@ -11,6 +11,7 @@ import { useActivitiesByWeek } from '../hooks/use_activities_by_week';
 import { useDelayedLoading } from '../hooks/use_delayed_loading';
 import { useTimeTrackingActive } from '../hooks/use_time_tracking_active';
 import { useTodosByDateRange } from '../hooks/use_todos_by_date_range';
+import { useUserTimeZone } from '../hooks/use_user_timezone';
 import { usePouchDb } from '../pouch_db';
 import type { ActivityItem } from './todo_board_helpers';
 import { migrateLocalTodosInBackground, migrateVisibleLegacyTodos } from './todo_migration';
@@ -129,10 +130,16 @@ export function useTodoBoardData({
   endDate: string;
   isInitialized: boolean;
 }) {
+  const timeZone = useUserTimeZone();
   const isVisibleMigrationDone = useVisibleTodoMigration(startDate, endDate, isInitialized);
   const isQueryEnabled = isInitialized && isVisibleMigrationDone;
   const todosQuery = useTodosByDateRange({ startDate, endDate, enabled: isQueryEnabled });
-  const activitiesQuery = useActivitiesByWeek({ startDate, endDate, enabled: isQueryEnabled });
+  const activitiesQuery = useActivitiesByWeek({
+    startDate,
+    endDate,
+    timeZone,
+    enabled: isQueryEnabled,
+  });
   const timeTrackingQuery = useTimeTrackingActive({ enabled: isQueryEnabled });
 
   const activities = useMemo(

--- a/packages/web-client/src/hooks/use_activities_by_week.ts
+++ b/packages/web-client/src/hooks/use_activities_by_week.ts
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 
-import type { Activity, Todo } from '@eddo/core-shared';
+import { getUtcRangeForTimeZoneDate, type Activity, type Todo } from '@eddo/core-shared';
 import { usePouchDb } from '../pouch_db';
 
 /** Maximum number of activity range queries to keep in cache */
@@ -32,22 +32,26 @@ interface UseActivitiesByWeekParams {
   startDate: string;
   /** End date in YYYY-MM-DD format */
   endDate: string;
+  /** IANA timezone for local day boundaries */
+  timeZone: string;
   enabled?: boolean;
 }
 
 /**
  * Fetches activities (time tracking entries) for a date range.
  * Uses Mango query to find todos with active entries, then expands and filters client-side.
- * Uses date-only strings (YYYY-MM-DD) for comparison to avoid timezone issues.
+ * Converts local date boundaries to UTC for timezone-aware comparisons.
  *
  * @param startDate - Start date in YYYY-MM-DD format
  * @param endDate - End date in YYYY-MM-DD format
+ * @param timeZone - IANA timezone for local day boundaries
  * @param enabled - Whether the query should run
  * @returns TanStack Query result with activities data
  */
 export function useActivitiesByWeek({
   startDate,
   endDate,
+  timeZone,
   enabled = true,
 }: UseActivitiesByWeekParams) {
   const { safeDb } = usePouchDb();
@@ -59,14 +63,15 @@ export function useActivitiesByWeek({
   }, [queryClient, startDate, endDate]);
 
   return useQuery({
-    queryKey: ['activities', 'byActive', startDate, endDate],
+    queryKey: ['activities', 'byActive', startDate, endDate, timeZone],
     queryFn: async () => {
       const timerId = `fetchActivities-${Date.now()}`;
       console.time(timerId);
 
-      // Use date-only prefix for comparison (avoids timezone issues)
-      const startKey = startDate;
-      const endKey = endDate + 'T\uffff';
+      const startRange = getUtcRangeForTimeZoneDate(startDate, timeZone);
+      const endRange = getUtcRangeForTimeZoneDate(endDate, timeZone);
+      const startKey = startRange.start;
+      const endKey = endRange.end;
 
       // Use Mango to find todos that have active entries
       // Note: PouchDB defaults to limit=25, so we set a high limit
@@ -82,8 +87,10 @@ export function useActivitiesByWeek({
       const activities: Activity[] = [];
       for (const todo of todos) {
         for (const [from, to] of Object.entries(todo.active)) {
-          // Check if this activity overlaps with the date range using date prefix comparison
-          if (from >= startKey && from <= endKey) {
+          const effectiveTo = to ?? new Date().toISOString();
+          const overlapsRange = from <= endKey && effectiveTo >= startKey;
+
+          if (overlapsRange) {
             activities.push({
               doc: todo,
               from,


### PR DESCRIPTION
## Summary

- Uses the user timezone when generating daily recap prompts.
- Applies timezone-local UTC boundaries to web activity reports.
- Includes overlapping time-tracking sessions in activity range results.

## Checks

- pnpm tsc:check
- pnpm lint
- pnpm lint:format